### PR TITLE
Add encoding tag for erlang R17 compiler

### DIFF
--- a/src/external/emysql/src/mysql.erl
+++ b/src/external/emysql/src/mysql.erl
@@ -1,3 +1,4 @@
+%%% Encoding: latin-1
 %%% File    : mysql.erl
 %%% Author  : Magnus Ahltorp <ahltorp@nada.kth.se>
 %%% Descrip.: MySQL client.

--- a/src/external/emysql/src/mysql_auth.erl
+++ b/src/external/emysql/src/mysql_auth.erl
@@ -1,4 +1,5 @@
 %%%-------------------------------------------------------------------
+%%% Encoding: latin-1
 %%% File    : mysql_auth.erl
 %%% Author  : Fredrik Thulin <ft@it.su.se>
 %%% Descrip.: MySQL client authentication functions.

--- a/src/external/emysql/src/mysql_conn.erl
+++ b/src/external/emysql/src/mysql_conn.erl
@@ -1,4 +1,5 @@
 %%%-------------------------------------------------------------------
+%%% Encoding: latin-1
 %%% File    : mysql_conn.erl
 %%% Author  : Fredrik Thulin <ft@it.su.se>
 %%% Descrip.: MySQL connection handler, handles de-framing of messages

--- a/src/external/emysql/src/mysql_recv.erl
+++ b/src/external/emysql/src/mysql_recv.erl
@@ -1,4 +1,5 @@
 %%%-------------------------------------------------------------------
+%%% Encoding: latin-1
 %%% File    : mysql_recv.erl
 %%% Author  : Fredrik Thulin <ft@it.su.se>
 %%% Descrip.: Handles data being received on a MySQL socket. Decodes


### PR DESCRIPTION
In Erlang/OTP R17 the default encoding of files will be UTF-8. This fix labels the files below as using latin-1 encoding so that the compiler is happy. 
