### PR TITLE
Fix hello_world3 example

### DIFF
--- a/examples/hello_world3/apps/hello_world3/src/hello_world3.app.src
+++ b/examples/hello_world3/apps/hello_world3/src/hello_world3.app.src
@@ -8,5 +8,6 @@
    {applications, [
         cloudi_core,
         cloudi_services_internal,
+        cloudi_services_databases,
         stdlib,
         kernel]}]}.


### PR DESCRIPTION
Need to explicitly include cloudi_services_databases. WIthout this, hello_world3 cannot be started.
