### PR TITLE
update erlasticsearch to take json docs

### DIFF
--- a/src/external/README.markdown
+++ b/src/external/README.markdown
@@ -72,7 +72,7 @@ to its integration and dependencies).
 
 - `https://github.com/dieswaytoofast/erlasticsearch`
 - `tag v1.3`
-- `Mon Jun 10 08:01:52 EST 2013`
+- `Thu Sep 26 15:50:56 2013 -0400`
 - `BSD`
 
 `erlang_cassandra`
@@ -211,8 +211,8 @@ to its integration and dependencies).
 `Erlang Thrift software library`
 
 - `https://github.com/dieswaytoofast/thrift`
-- `commit f367c54ffcd522d9522c8ed0872c397be24da967`
-- `Sun May 19 17:13:30 EDT 2013`
+- `commit 0b8efd728f2ff2106d5e15e3c65c8ef895451c0a`
+- `Thu Sep 26 16:19:26 2013 -0400`
 - `Apache License`
 
 `zeromq/v?/erlzmq`

--- a/src/external/jsx/src/jsx.app.src
+++ b/src/external/jsx/src/jsx.app.src
@@ -1,7 +1,7 @@
 {application, jsx,
 [
     {description, "a streaming, evented json parsing toolkit"},
-    {vsn, "1.4.1"},
+    {vsn, "1.4.3"},
     {modules, [
         jsx,
         jsx_encoder,

--- a/src/external/jsx/src/jsx_decoder.erl
+++ b/src/external/jsx/src/jsx_decoder.erl
@@ -293,61 +293,40 @@ key(Bin, Handler, Stack, Config) ->
 
 %% explicitly whitelist ascii set for faster parsing. really? really. someone should
 %%  submit a patch that unrolls simple guards
-%% ordering is for efficiency but is nowhere near optimal
 %% note that if you encounter an error from string and you can't find the clause that
 %%  caused it here, it might be in unescape below
-string(<<97, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 97), Stack, Config);
-string(<<98, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 98), Stack, Config);
-string(<<99, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 99), Stack, Config);
-string(<<100, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 100), Stack, Config);
-string(<<101, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 101), Stack, Config);
-string(<<102, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 102), Stack, Config);
-string(<<103, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 103), Stack, Config);
-string(<<104, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 104), Stack, Config);
-string(<<105, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 105), Stack, Config);
-string(<<106, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 106), Stack, Config);
-string(<<107, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 107), Stack, Config);
-string(<<108, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 108), Stack, Config);
-string(<<109, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 109), Stack, Config);
-string(<<110, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 110), Stack, Config);
-string(<<111, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 111), Stack, Config);
-string(<<112, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 112), Stack, Config);
-string(<<113, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 113), Stack, Config);
-string(<<114, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 114), Stack, Config);
-string(<<115, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 115), Stack, Config);
-string(<<116, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 116), Stack, Config);
-string(<<117, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 117), Stack, Config);
-string(<<118, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 118), Stack, Config);
-string(<<119, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 119), Stack, Config);
-string(<<120, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 120), Stack, Config);
-string(<<121, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 121), Stack, Config);
-string(<<122, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 122), Stack, Config);
+string(<<32, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 32), Stack, Config);
+string(<<33, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 33), Stack, Config);
+string(<<?doublequote, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    doublequote(Rest, Handler, Acc, Stack, Config);
+string(<<35, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 35), Stack, Config);
+string(<<36, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 36), Stack, Config);
+string(<<37, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 37), Stack, Config);
+string(<<38, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 38), Stack, Config);
+string(<<?singlequote, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    singlequote(Rest, Handler, Acc, Stack, Config);
+string(<<40, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 40), Stack, Config);
+string(<<41, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 41), Stack, Config);
+string(<<42, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 42), Stack, Config);
+string(<<43, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 43), Stack, Config);
+string(<<44, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 44), Stack, Config);
+string(<<45, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 45), Stack, Config);
+string(<<46, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 46), Stack, Config);
+string(<<?solidus, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, maybe_replace(?solidus, Config)), Stack, Config);
 string(<<48, Rest/binary>>, Handler, Acc, Stack, Config) ->
     string(Rest, Handler, acc_seq(Acc, 48), Stack, Config);
 string(<<49, Rest/binary>>, Handler, Acc, Stack, Config) ->
@@ -368,6 +347,20 @@ string(<<56, Rest/binary>>, Handler, Acc, Stack, Config) ->
     string(Rest, Handler, acc_seq(Acc, 56), Stack, Config);
 string(<<57, Rest/binary>>, Handler, Acc, Stack, Config) ->
     string(Rest, Handler, acc_seq(Acc, 57), Stack, Config);
+string(<<58, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 58), Stack, Config);
+string(<<59, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 59), Stack, Config);
+string(<<60, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 60), Stack, Config);
+string(<<61, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 61), Stack, Config);
+string(<<62, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 62), Stack, Config);
+string(<<63, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 63), Stack, Config);
+string(<<64, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 64), Stack, Config);
 string(<<65, Rest/binary>>, Handler, Acc, Stack, Config) ->
     string(Rest, Handler, acc_seq(Acc, 65), Stack, Config);
 string(<<66, Rest/binary>>, Handler, Acc, Stack, Config) ->
@@ -420,52 +413,10 @@ string(<<89, Rest/binary>>, Handler, Acc, Stack, Config) ->
     string(Rest, Handler, acc_seq(Acc, 89), Stack, Config);
 string(<<90, Rest/binary>>, Handler, Acc, Stack, Config) ->
     string(Rest, Handler, acc_seq(Acc, 90), Stack, Config);
-string(<<32, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 32), Stack, Config);
-string(<<33, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 33), Stack, Config);
-string(<<?doublequote, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    doublequote(Rest, Handler, Acc, Stack, Config);
-string(<<35, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 35), Stack, Config);
-string(<<36, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 36), Stack, Config);
-string(<<37, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 37), Stack, Config);
-string(<<38, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 38), Stack, Config);
-string(<<?singlequote, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    singlequote(Rest, Handler, Acc, Stack, Config);
-string(<<40, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 40), Stack, Config);
-string(<<41, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 41), Stack, Config);
-string(<<42, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 42), Stack, Config);
-string(<<43, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 43), Stack, Config);
-string(<<44, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 44), Stack, Config);
-string(<<45, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 45), Stack, Config);
-string(<<46, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 46), Stack, Config);
-string(<<58, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 58), Stack, Config);
-string(<<59, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 59), Stack, Config);
-string(<<60, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 60), Stack, Config);
-string(<<61, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 61), Stack, Config);
-string(<<62, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 62), Stack, Config);
-string(<<63, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 63), Stack, Config);
-string(<<64, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, 64), Stack, Config);
 string(<<91, Rest/binary>>, Handler, Acc, Stack, Config) ->
     string(Rest, Handler, acc_seq(Acc, 91), Stack, Config);
+string(<<?rsolidus/utf8, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    unescape(Rest, Handler, Acc, Stack, Config);
 string(<<93, Rest/binary>>, Handler, Acc, Stack, Config) ->
     string(Rest, Handler, acc_seq(Acc, 93), Stack, Config);
 string(<<94, Rest/binary>>, Handler, Acc, Stack, Config) ->
@@ -474,6 +425,58 @@ string(<<95, Rest/binary>>, Handler, Acc, Stack, Config) ->
     string(Rest, Handler, acc_seq(Acc, 95), Stack, Config);
 string(<<96, Rest/binary>>, Handler, Acc, Stack, Config) ->
     string(Rest, Handler, acc_seq(Acc, 96), Stack, Config);
+string(<<97, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 97), Stack, Config);
+string(<<98, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 98), Stack, Config);
+string(<<99, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 99), Stack, Config);
+string(<<100, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 100), Stack, Config);
+string(<<101, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 101), Stack, Config);
+string(<<102, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 102), Stack, Config);
+string(<<103, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 103), Stack, Config);
+string(<<104, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 104), Stack, Config);
+string(<<105, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 105), Stack, Config);
+string(<<106, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 106), Stack, Config);
+string(<<107, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 107), Stack, Config);
+string(<<108, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 108), Stack, Config);
+string(<<109, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 109), Stack, Config);
+string(<<110, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 110), Stack, Config);
+string(<<111, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 111), Stack, Config);
+string(<<112, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 112), Stack, Config);
+string(<<113, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 113), Stack, Config);
+string(<<114, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 114), Stack, Config);
+string(<<115, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 115), Stack, Config);
+string(<<116, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 116), Stack, Config);
+string(<<117, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 117), Stack, Config);
+string(<<118, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 118), Stack, Config);
+string(<<119, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 119), Stack, Config);
+string(<<120, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 120), Stack, Config);
+string(<<121, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 121), Stack, Config);
+string(<<122, Rest/binary>>, Handler, Acc, Stack, Config) ->
+    string(Rest, Handler, acc_seq(Acc, 122), Stack, Config);
 string(<<123, Rest/binary>>, Handler, Acc, Stack, Config) ->
     string(Rest, Handler, acc_seq(Acc, 123), Stack, Config);
 string(<<124, Rest/binary>>, Handler, Acc, Stack, Config) ->
@@ -484,10 +487,6 @@ string(<<126, Rest/binary>>, Handler, Acc, Stack, Config) ->
     string(Rest, Handler, acc_seq(Acc, 126), Stack, Config);
 string(<<127, Rest/binary>>, Handler, Acc, Stack, Config) ->
     string(Rest, Handler, acc_seq(Acc, 127), Stack, Config);
-string(<<?rsolidus/utf8, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    unescape(Rest, Handler, Acc, Stack, Config);
-string(<<?solidus, Rest/binary>>, Handler, Acc, Stack, Config) ->
-    string(Rest, Handler, acc_seq(Acc, maybe_replace(?solidus, Config)), Stack, Config);
 string(<<C, Rest/binary>>, Handler, Acc, Stack, Config=#config{dirty_strings=true}) ->
     string(Rest, Handler, acc_seq(Acc, C), Stack, Config);
 string(<<X/utf8, Rest/binary>>, Handler, Acc, Stack, Config) when X >= 16#20, X < 16#2028 ->
@@ -532,6 +531,19 @@ string(<<X/utf8, Rest/binary>>, Handler, Acc, Stack, Config) when X >= 16#f0000,
     string(Rest, Handler, acc_seq(Acc, X), Stack, Config);
 string(<<X/utf8, Rest/binary>>, Handler, Acc, Stack, Config) when X >= 16#100000, X < 16#10fffe ->
     string(Rest, Handler, acc_seq(Acc, X), Stack, Config);
+%% partial utf8 codepoints. check that input could possibly be valid before attempting
+%%  to correct
+string(<<>>, Handler, Acc, Stack, Config) ->
+    incomplete(string, <<>>, Handler, Acc, Stack, Config);
+string(<<X>>, Handler, Acc, Stack, Config) when X >= 16#c2, X =< 16#f4 ->
+    incomplete(string, <<X>>, Handler, Acc, Stack, Config);
+string(<<X, Y>>, Handler, Acc, Stack, Config) when X >= 16#e0, X =< 16#f4, Y >= 16#80, Y =< 16#bf ->
+    incomplete(string, <<X, Y>>, Handler, Acc, Stack, Config);
+string(<<X, Y, Z>>, Handler, Acc, Stack, Config)
+        when X >= 16#f0, X =< 16#f4,
+            Y >= 16#80, Y =< 16#bf,
+            Z >= 16#80, Z =< 16#bf ->
+    incomplete(string, <<X, Y, Z>>, Handler, Acc, Stack, Config); 
 %% surrogates
 string(<<237, X, _, Rest/binary>>, Handler, Acc, Stack, Config=#config{replaced_bad_utf8=true})
         when X >= 160 ->
@@ -560,10 +572,7 @@ string(<<X, Rest/binary>>, Handler, Acc, Stack, Config=#config{replaced_bad_utf8
 string(<<_, Rest/binary>>, Handler, Acc, Stack, Config=#config{replaced_bad_utf8=true}) ->
     string(Rest, Handler, acc_seq(Acc, 16#fffd), Stack, Config);
 string(Bin, Handler, Acc, Stack, Config) ->
-    case is_partial_utf(Bin) of
-        true -> incomplete(string, Bin, Handler, Acc, Stack, Config);
-        false -> ?error(string, Bin, Handler, Acc, Stack, Config)
-    end.
+    ?error(string, Bin, Handler, Acc, Stack, Config).
 
 
 doublequote(<<Rest/binary>>, Handler, Acc, [key|_] = Stack, Config) ->
@@ -582,20 +591,6 @@ singlequote(<<Rest/binary>>, Handler, Acc, [singlequote|Stack], Config) ->
     maybe_done(Rest, handle_event({string, end_seq(Acc, Config)}, Handler, Config), Stack, Config);
 singlequote(<<Rest/binary>>, Handler, Acc, Stack, Config) ->
     string(Rest, Handler, acc_seq(Acc, ?singlequote), Stack, Config).
-
-
-%% when parsing strings, the naive detection of partial codepoints is
-%%   insufficient. this incredibly anal function should detect all badly formed
-%%   utf sequences
-is_partial_utf(<<>>) -> true;
-is_partial_utf(<<X>>) when X >= 16#c2, X =< 16#f4 -> true;
-is_partial_utf(<<X, Y>>) when X >= 16#e0, X =< 16#f4, Y >= 16#80, Y =< 16#bf -> true;
-is_partial_utf(<<X, Y, Z>>)
-        when X >= 16#f0, X =< 16#f4,
-            Y >= 16#80, Y =< 16#bf,
-            Z >= 16#80, Z =< 16#bf ->
-    true;
-is_partial_utf(_) -> false.
 
 
 %% strips continuation bytes after bad utf bytes, guards against both too short

--- a/src/external/jsx/src/jsx_encoder.erl
+++ b/src/external/jsx/src/jsx_encoder.erl
@@ -72,8 +72,6 @@ value([{}], {Handler, State}, _Config) ->
     Handler:handle_event(end_object, Handler:handle_event(start_object, State));
 value([], {Handler, State}, _Config) ->
     Handler:handle_event(end_array, Handler:handle_event(start_array, State));
-value([Tuple|_] = List, Handler, Config) when is_tuple(Tuple) ->
-    list_or_object(List, Handler, Config);
 value(List, Handler, Config) when is_list(List) ->
     list_or_object(List, Handler, Config);
 value(Term, Handler, Config) -> ?error(value, Term, Handler, Config).
@@ -115,7 +113,8 @@ object([{Key, Value}], {Handler, State}, Config) when is_atom(Key); is_binary(Ke
         },
         Config
     );
-object([], {Handler, State}, _Config) -> Handler:handle_event(end_object, State).
+object([], {Handler, State}, _Config) -> Handler:handle_event(end_object, State);
+object(Term, Handler, Config) -> ?error(object, Term, Handler, Config).
 
 
 list([Value, Next|Rest], {Handler, State}, Config) ->

--- a/src/external/jsx/src/jsx_parser.erl
+++ b/src/external/jsx/src/jsx_parser.erl
@@ -24,6 +24,7 @@
 -module(jsx_parser).
 
 -export([parser/3, resume/5]).
+-export([init/1, handle_event/2]).
 
 
 -spec parser(Handler::module(), State::any(), Config::jsx:config()) -> jsx:parser().
@@ -134,6 +135,8 @@ value([{string, String}|Tokens], Handler, Stack, Config) when is_binary(String) 
     end;
 value([String|Tokens], Handler, Stack, Config) when is_binary(String) ->
     value([{string, String}] ++ Tokens, Handler, Stack, Config);
+value([{raw, Raw}|Tokens], Handler, Stack, Config) when is_binary(Raw) ->
+    value((jsx:decoder(?MODULE, [], []))(Raw) ++ Tokens, Handler, Stack, Config);
 value([], Handler, Stack, Config) ->
     incomplete(value, Handler, Stack, Config);
 value(BadTokens, Handler, Stack, Config) when is_list(BadTokens) ->
@@ -202,6 +205,13 @@ clean_string(Bin, Tokens, Handler, Stack, Config) ->
         {error, badarg} -> ?error(string, [{string, Bin}|Tokens], Handler, Stack, Config);
         String -> String
     end.
+
+
+%% for raw input
+init([]) -> [].
+
+handle_event(end_json, State) -> lists:reverse(State);
+handle_event(Event, State) -> [Event] ++ State.
 
 
 -include("jsx_strings.hrl").
@@ -282,6 +292,23 @@ custom_incomplete_handler_test_() ->
         {"custom incomplete handler", ?_assertError(
             badarg,
             parse_error([], [{incomplete_handler, fun(_, _, _) -> erlang:error(badarg) end}])
+        )}
+    ].
+
+
+raw_test_() ->
+    [
+        {"raw empty list", ?_assertEqual(
+            [start_array, end_array, end_json],
+            parse([{raw, <<"[]">>}], [])
+        )},
+        {"raw empty object", ?_assertEqual(
+            [start_object, end_object, end_json],
+            parse([{raw, <<"{}">>}], [])
+        )},
+        {"raw chunk inside stream", ?_assertEqual(
+            [start_object, {key, <<"key">>}, start_array, {literal, true}, end_array, end_object, end_json],
+            parse([start_object, {key, <<"key">>}, {raw, <<"[true]">>}, end_object], [])
         )}
     ].
 

--- a/src/external/jsx/src/jsx_to_json.erl
+++ b/src/external/jsx/src/jsx_to_json.erl
@@ -45,7 +45,8 @@ to_json(Source, Config) when is_list(Config) ->
 -spec format(Source::binary(), Config::config()) -> binary().
 
 format(Source, Config) when is_binary(Source) andalso is_list(Config) ->
-    (jsx:decoder(?MODULE, Config, jsx_config:extract_config(Config ++ [escaped_strings])))(Source).
+    (jsx:decoder(?MODULE, Config, jsx_config:extract_config(Config ++ [escaped_strings])))(Source);
+format(_, _) -> erlang:error(badarg).
 
 
 parse_config(Config) -> parse_config(Config, #config{}).

--- a/src/external/jsx/src/jsx_to_term.erl
+++ b/src/external/jsx/src/jsx_to_term.erl
@@ -53,7 +53,7 @@ to_term(Source, Config) when is_list(Config) ->
 parse_config(Config) -> parse_config(Config, #config{}).
 
 parse_config([{labels, Val}|Rest], Config)
-        when Val == binary; Val == atom; Val == existing_atom ->
+        when Val == binary; Val == atom; Val == existing_atom; Val == attempt_atom ->
     parse_config(Rest, Config#config{labels = Val});
 parse_config([labels|Rest], Config) ->
     parse_config(Rest, Config#config{labels = binary});
@@ -107,6 +107,12 @@ format_key(Key, Config) ->
         binary -> Key
         ; atom -> binary_to_atom(Key, utf8)
         ; existing_atom -> binary_to_existing_atom(Key, utf8)
+        ; attempt_atom ->
+            try binary_to_existing_atom(Key, utf8) of
+                Result -> Result
+            catch
+                error:badarg -> Key
+            end
     end.
 
 
@@ -133,6 +139,10 @@ config_test_() ->
             #config{labels=existing_atom},
             parse_config([{labels, existing_atom}])
         )},
+        {"sloppy existing atom labels", ?_assertEqual(
+            #config{labels=attempt_atom},
+            parse_config([{labels, attempt_atom}])
+        )},
         {"post decode", ?_assertEqual(
             #config{post_decode=F},
             parse_config([{post_decode, F}])
@@ -154,6 +164,14 @@ format_key_test_() ->
         {"nonexisting atom key", ?_assertError(
             badarg,
             format_key(<<"nonexistentatom">>, #config{labels=existing_atom})
+        )},
+        {"sloppy existing atom key", ?_assertEqual(
+            key,
+            format_key(<<"key">>, #config{labels=attempt_atom})
+        )},
+        {"nonexisting atom key", ?_assertEqual(
+            <<"nonexistentatom">>,
+            format_key(<<"nonexistentatom">>, #config{labels=attempt_atom})
         )}
     ].
 

--- a/src/external/thrift/src/thrift.app.src
+++ b/src/external/thrift/src/thrift.app.src
@@ -23,7 +23,7 @@
   {description, "Thrift bindings"},
 
   % The version of the applicaton
-  {vsn, "0.9.0"},
+  {vsn, "0.9.2"},
 
   % All modules used by the application.
   {modules, [

--- a/src/lib/cloudi_services_databases/rebar.config
+++ b/src/lib/cloudi_services_databases/rebar.config
@@ -1,6 +1,7 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
 % ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
 
+{lib_dirs, ["..", "../../external", "../../external/nodefinder", "../../external/zeromq/v3"]}.
 {clean_files, ["test_ct/*.beam"]}.
 {ct_dir, "test_ct"}.
 {ct_log_dir, "test_ct/logs"}.

--- a/src/lib/cloudi_services_databases/src/cloudi_service_db_elasticsearch.erl
+++ b/src/lib/cloudi_services_databases/src/cloudi_service_db_elasticsearch.erl
@@ -244,7 +244,7 @@ create_index(Dispatcher, Name, Index)
     {ok, response()} |
     {error, any()}.
 create_index(Dispatcher, Name, Index, Doc)
-    when is_list(Name), is_binary(Index), is_binary(Doc) ->
+    when is_list(Name), is_binary(Index), (is_binary(Doc) orelse is_list(Doc)) ->
     cloudi:send_sync(Dispatcher, Name,
                      {create_index, Index, Doc}).
 
@@ -302,7 +302,7 @@ is_index(Dispatcher, Name, Indexes)
     {ok, boolean()} |
     {error, any()}.
 count(Dispatcher, Name, Doc)
-    when is_list(Name), is_binary(Doc) ->
+    when is_list(Name), (is_binary(Doc) orelse is_list(Doc)) ->
     count(Dispatcher, Name, ?ALL, [], Doc, []).
 
 %% _equiv count(Dispatcher, Name, ?ALL, [], Doc, Params).
@@ -310,7 +310,7 @@ count(Dispatcher, Name, Doc)
     {ok, boolean()} |
     {error, any()}.
 count(Dispatcher, Name, Doc, Params)
-    when is_list(Name), is_binary(Doc), is_list(Params) ->
+    when is_list(Name), (is_binary(Doc) orelse is_list(Doc)), is_list(Params) ->
     count(Dispatcher, Name, ?ALL, [], Doc, Params).
 
 %% _equiv count(Dispatcher, Name, Index, [], Doc, Params).
@@ -318,10 +318,10 @@ count(Dispatcher, Name, Doc, Params)
     {ok, boolean()} |
     {error, any()}.
 count(Dispatcher, Name, Index, Doc, Params)
-    when is_list(Name), is_binary(Index), is_binary(Doc), is_list(Params) ->
+    when is_list(Name), is_binary(Index), (is_binary(Doc) orelse is_list(Doc)), is_list(Params) ->
     count(Dispatcher, Name, [Index], [], Doc, Params);
 count(Dispatcher, Name, Indexes, Doc, Params)
-    when is_list(Name), is_list(Indexes), is_binary(Doc), is_list(Params) ->
+    when is_list(Name), is_list(Indexes), (is_binary(Doc) orelse is_list(Doc)), is_list(Params) ->
     count(Dispatcher, Name, Indexes, [], Doc, Params).
 
 %% @doc Get the number of matches for a query
@@ -331,19 +331,19 @@ count(Dispatcher, Name, Indexes, Doc, Params)
     {error, any()}.
 count(Dispatcher, Name, Index, Type, Doc, Params)
     when is_list(Name), is_binary(Index), is_binary(Type),
-         is_binary(Doc), is_list(Params) ->
+         (is_binary(Doc) orelse is_list(Doc)), is_list(Params) ->
     count(Dispatcher, Name, [Index], [Type], Doc, Params);
 count(Dispatcher, Name, Indexes, Type, Doc, Params)
     when is_list(Name), is_list(Indexes), is_binary(Type),
-         is_binary(Doc), is_list(Params) ->
+         (is_binary(Doc) orelse is_list(Doc)), is_list(Params) ->
     count(Dispatcher, Name, Indexes, [Type], Doc, Params);
 count(Dispatcher, Name, Index, Types, Doc, Params)
     when is_list(Name), is_binary(Index), is_list(Types),
-         is_binary(Doc), is_list(Params) ->
+         (is_binary(Doc) orelse is_list(Doc)), is_list(Params) ->
     count(Dispatcher, Name, [Index], Types, Doc, Params);
 count(Dispatcher, Name, Indexes, Types, Doc, Params)
     when is_list(Name), is_list(Indexes), is_list(Types),
-         is_binary(Doc), is_list(Params) ->
+         (is_binary(Doc) orelse is_list(Doc)), is_list(Params) ->
     cloudi:send_sync(Dispatcher, Name,
                      {count, Indexes, Types, Doc, Params}).
 
@@ -352,7 +352,7 @@ count(Dispatcher, Name, Indexes, Types, Doc, Params)
     {ok, boolean()} |
     {error, any()}.
 delete_by_query(Dispatcher, Name, Doc)
-    when is_list(Name), is_binary(Doc) ->
+    when is_list(Name), (is_binary(Doc) orelse is_list(Doc)) ->
     delete_by_query(Dispatcher, Name, ?ALL, [], Doc, []).
 
 %% _equiv delete_by_query(Dispatcher, Name, ?ALL, [], Doc, Params).
@@ -360,7 +360,7 @@ delete_by_query(Dispatcher, Name, Doc)
     {ok, boolean()} |
     {error, any()}.
 delete_by_query(Dispatcher, Name, Doc, Params)
-    when is_list(Name), is_binary(Doc), is_list(Params) ->
+    when is_list(Name), (is_binary(Doc) orelse is_list(Doc)), is_list(Params) ->
     delete_by_query(Dispatcher, Name, ?ALL, [], Doc, Params).
 
 %% _equiv delete_by_query(Dispatcher, Name, Index, [], Doc, Params).
@@ -369,10 +369,10 @@ delete_by_query(Dispatcher, Name, Doc, Params)
     {ok, boolean()} |
     {error, any()}.
 delete_by_query(Dispatcher, Name, Index, Doc, Params)
-    when is_list(Name), is_binary(Index), is_binary(Doc), is_list(Params) ->
+    when is_list(Name), is_binary(Index), (is_binary(Doc) orelse is_list(Doc)), is_list(Params) ->
     delete_by_query(Dispatcher, Name, [Index], [], Doc, Params);
 delete_by_query(Dispatcher, Name, Indexes, Doc, Params)
-    when is_list(Name), is_list(Indexes), is_binary(Doc), is_list(Params) ->
+    when is_list(Name), is_list(Indexes), (is_binary(Doc) orelse is_list(Doc)), is_list(Params) ->
     delete_by_query(Dispatcher, Name, Indexes, [], Doc, Params).
 
 %% @doc Get the number of matches for a query
@@ -382,19 +382,19 @@ delete_by_query(Dispatcher, Name, Indexes, Doc, Params)
     {error, any()}.
 delete_by_query(Dispatcher, Name, Index, Type, Doc, Params)
     when is_list(Name), is_binary(Index), is_binary(Type),
-         is_binary(Doc), is_list(Params) ->
+         (is_binary(Doc) orelse is_list(Doc)), is_list(Params) ->
     delete_by_query(Dispatcher, Name, [Index], [Type], Doc, Params);
 delete_by_query(Dispatcher, Name, Indexes, Type, Doc, Params)
     when is_list(Name), is_list(Indexes), is_binary(Type),
-         is_binary(Doc), is_list(Params) ->
+         (is_binary(Doc) orelse is_list(Doc)), is_list(Params) ->
     delete_by_query(Dispatcher, Name, Indexes, [Type], Doc, Params);
 delete_by_query(Dispatcher, Name, Index, Types, Doc, Params)
     when is_list(Name), is_binary(Index), is_list(Types),
-         is_binary(Doc), is_list(Params) ->
+         (is_binary(Doc) orelse is_list(Doc)), is_list(Params) ->
     delete_by_query(Dispatcher, Name, [Index], Types, Doc, Params);
 delete_by_query(Dispatcher, Name, Indexes, Types, Doc, Params)
     when is_list(Name), is_list(Indexes), is_list(Types),
-         is_binary(Doc), is_list(Params) ->
+         (is_binary(Doc) orelse is_list(Doc)), is_list(Params) ->
     cloudi:send_sync(Dispatcher, Name,
                      {delete_by_query, Indexes, Types, Doc, Params}).
 
@@ -421,7 +421,7 @@ is_type(Dispatcher, Name, Indexes, Types)
     {ok, response()} |
     {error, any()}.
 insert_doc(Dispatcher, Name, Index, Type, Id, Doc)
-    when is_list(Name), is_binary(Index), is_binary(Type), is_binary(Doc) ->
+    when is_list(Name), is_binary(Index), is_binary(Type), (is_binary(Doc) orelse is_list(Doc)) ->
     insert_doc(Dispatcher, Name, Index, Type, Id, Doc, []).
 
 %% @doc Insert a doc into the ElasticSearch cluster
@@ -431,7 +431,7 @@ insert_doc(Dispatcher, Name, Index, Type, Id, Doc)
     {error, any()}.
 insert_doc(Dispatcher, Name, Index, Type, Id, Doc, Params)
     when is_list(Name), is_binary(Index), is_binary(Type),
-         is_binary(Doc), is_list(Params) ->
+         (is_binary(Doc) orelse is_list(Doc)), is_list(Params) ->
     cloudi:send_sync(Dispatcher, Name,
                      {insert_doc, Index, Type, Id, Doc, Params}).
 
@@ -466,7 +466,7 @@ get_doc(Dispatcher, Name, Index, Type, Id, Params)
     {ok, response()} |
     {error, any()}.
 mget_doc(Dispatcher, Name, Doc)
-    when is_list(Name), is_binary(Doc) ->
+    when is_list(Name), (is_binary(Doc) orelse is_list(Doc)) ->
     mget_doc(Dispatcher, Name, <<>>, <<>>, Doc).
 
 %% _equiv mget_doc(Dispatcher, Name, Index, <<>>, Doc)
@@ -474,7 +474,7 @@ mget_doc(Dispatcher, Name, Doc)
     {ok, response()} |
     {error, any()}.
 mget_doc(Dispatcher, Name, Index, Doc)
-    when is_list(Name), is_binary(Index), is_binary(Doc) ->
+    when is_list(Name), is_binary(Index), (is_binary(Doc) orelse is_list(Doc)) ->
     mget_doc(Dispatcher, Name, Index, <<>>, Doc).
 
 %% @doc Get a doc from the ElasticSearch cluster
@@ -482,7 +482,7 @@ mget_doc(Dispatcher, Name, Index, Doc)
     {ok, response()} |
     {error, any()}.
 mget_doc(Dispatcher, Name, Index, Type, Doc)
-    when is_list(Name), is_binary(Index), is_binary(Type), is_binary(Doc) ->
+    when is_list(Name), is_binary(Index), is_binary(Type), (is_binary(Doc) orelse is_list(Doc)) ->
     cloudi:send_sync(Dispatcher, Name,
                      {mget_doc, Index, Type, Doc}).
 
@@ -508,7 +508,7 @@ delete_doc(Dispatcher, Name, Index, Type, Id, Params)
     {ok, response()} |
     {error, any()}.
 search(Dispatcher, Name, Index, Type, Doc)
-    when is_list(Name), is_binary(Index), is_binary(Type), is_binary(Doc) ->
+    when is_list(Name), is_binary(Index), is_binary(Type), (is_binary(Doc) orelse is_list(Doc)) ->
     search(Dispatcher, Name, Index, Type, Doc, []).
 
 %% @doc Search for docs in the ElasticSearch cluster
@@ -517,7 +517,7 @@ search(Dispatcher, Name, Index, Type, Doc)
     {error, any()}.
 search(Dispatcher, Name, Index, Type, Doc, Params)
     when is_list(Name), is_binary(Index), is_binary(Type),
-         is_binary(Doc), is_list(Params) ->
+         (is_binary(Doc) orelse is_list(Doc)), is_list(Params) ->
     cloudi:send_sync(Dispatcher, Name,
                      {search, Index, Type, Doc, Params}).
 


### PR DESCRIPTION
Updated erlasticsearch drivers to track dieswaytoofast/master, which had tag on effects w/ thrift and jsx.
Note that I don't know where else jsx is used, and consequently, while these _are_ point releases for jsx (1.4.1 to 1.4.3), I dunno what might have broken

Also, in cloudi_services_databases, I had to re-add 
`{lib_dirs, ["..", "../../external", "../../external/nodefinder", "../../external/zeromq/v3"]}.`
in rebar.config, without which the tests wouldn't run (for me at least)
- json docs must be jsx-able
- updated jsx version to 1.4.3
- updated thrift to support jsx 1.4.3
