### PR TITLE
use a predefined pool for keyspace ops

### DIFF
--- a/src/external/README.markdown
+++ b/src/external/README.markdown
@@ -88,8 +88,8 @@ to its integration and dependencies).
 `Erlang Cassandra (thrift) Driver`
 
 - `https://github.com/dieswaytoofast/erlang_cassandra`
-- `tag v1.0.4`
-- `Sat Oct 26 11:06:28 2013 -0400`
+- `tag v1.0.7`
+- `Sun Nov 10 10:31:36 2013 -0500`
 - `BSD`
 
 `etokyotyrant (medici)`

--- a/src/external/erlang_cassandra/README.md
+++ b/src/external/erlang_cassandra/README.md
@@ -6,26 +6,73 @@ Erlang thrift interface to Cassandra
 - This is just a tiny shim on the  complete list of (current) cassandra thrift commands, as [listed here](http://wiki.apache.org/cassandra/API10)
   - Yes, the returned data has all sorts of records in it. Sorry. Like I said, its a shim
 
-- ```CQL``` commands can be sent using the ```execute_cql_command```, ```prepare_cql_command```, and ```execute_prepared_cql_command``` metnds
+- Keyspaces correspond to [poolboy](https://github.com/devinus/poolboy) pools which are automagically started for you when you set them.  These pools are clobbered when  the keyspace is deleted (or the application is restarted).
 
-- pools are garbage-collected when  the keyspace is deleted (or the application is restarted)
+- ```CQL``` commands can be sent using the ```execute_cql_command```, ```prepare_cql_command```, and ```execute_prepared_cql_command``` methods.  Note that if you are using prepared cql commands, you will need to expliclty start a cql_pool and reference it (these have one and only one worker). Check out ```start_cql_pool/1``` for more info.
 
 
 Liberally takes ideas from
 [Louis-Philippe Gauthier's](https://github.com/lpgauth) truly excellent [cassanderl](https://github.com/lpgauth/cassanderl), but with a more recent version of [thrift](https://github.com/dieswaytoofast/thrift) (19.36.0), and [poolboy](https://github.com/devinus/poolboy) instead of [dispcount](https://github.com/ferd/dispcount)
 
-***NOTE***
-
-There is a one-to-one mapping between keyspaces and pools. If you want something other than the default number of workers for a given keyspace, use ```start_pool``` *first*, and *then* access the keyspace, i.e.
-
-HOWTO
+Howto
 ============
 
-1. Make sure you have Cassandra running.
-2. Start up a erlang_cassandra
+*  Make sure you have Cassandra running.
+*  Start up erlang_cassandra
+
 ```erlang
 erlang_cassandra@paglierino)1> erlang_cassandra:start().
 ```  
-3. Take a look at the exports in ```erlang_cassara.erl```.  In general, whenever you reference a Keyspace (e.g. ```insert(Keyspace, RowKey, ColumnParent, Column, ConsistencyLevel)```), you can use a **Destination** instead of a **Keyspace**.
-A Destination is simply a triplet, i.e., ```{Host, Port, Keyspace}``` (this is relevant for when you might be running multiple Cassandra instances, though lord knows why you would do that). So, you would say ```insert({Host, Port, Keyspace}, RowKey, ColumnParent, Column, ConsistencyLevel)```
-4. For all the thrift commands that _don't_ take a Keyspace (e.g. ```system_update_keyspace```) you can either let the application deduce the Keyspace from the command, or you can explicitly specific it yourself.  e.g. both ```system_update_keyspace(KeyspaceDefinition)```,  ```system_update_keyspace(Keyspace, KeyspaceDefinition)``` and ```system_update_keyspace({Host, Port, Keyspace}, KeyspaceDefinition)``` are acceptable
+
+* Create a keyspace
+
+```erlang
+(erlang_cassandra@paglierino)2> erlang_cassandra:system_add_keyspace(erlang_cassandra:keyspace_definition(<<"foo">>)).
+{ok,<<"098e77e3-5e01-39e9-b840-ba0aba74f743">>}
+```
+
+
+* Set the keyspace for future commands (note that this also starts up a pool of thrift worker-bees)
+
+```erlang
+(erlang_cassandra@paglierino)3> erlang_cassandra:set_keyspace(<<"foo">>).
+{ok,ok}
+```
+* Do something
+
+```erlang
+(erlang_cassandra@paglierino)4> erlang_cassandra:describe_ring(<<"foo">>).
+{ok,[{tokenRange,<<"-4487853658134717437">>,
+                 <<"-4487853658134717437">>,
+                 [<<"127.0.0.1">>],
+                 [<<"127.0.0.1">>],
+                 [{endpointDetails,<<"127.0.0.1">>,<<"datacenter1">>,
+                                   <<"rack1">>}]}]}
+```
+
+
+Misc
+============
+
+* There is a one-to-one mapping between keyspaces and pools. If you want something other than the default number of workers for a given keyspace, use ```start_pool``` *first* with the keyspace_name as an argument, and *then* access the keyspace.  e.g.
+ 
+``` erlang
+(erlang_cassandra@paglierino)5> erlang_cassandra:start_pool(<<"bar">>, [{max_size, 10}]).
+{ok,<0.120.0>}
+(erlang_cassandra@paglierino)6> erlang_cassandra:set_keyspace(<<"bar">>).
+{ok,ok}
+```
+
+* Take a look at the exports in ```erlang_cassara.erl```
+   * In general, whenever you reference a Keyspace (e.g. ```insert(Keyspace, RowKey, ColumnParent, Column, ConsistencyLevel)```), you can use a **Destination** instead of a **Keyspace**.
+   * A Destination is simply a triplet, i.e., ```{Host, Port, Keyspace}``` (this is relevant for when you might be running multiple Cassandra instances, though lord knows why you would do that).
+   * As such, you could also use ```insert({Host, Port, Keyspace}, RowKey, ColumnParent, Column, ConsistencyLevel)```
+   * If you are relying on **Destination**, _always pass in the **Destination** in your commands_. e.g.
+       * instead of ```erlang_cassandra:set_keyspace(<<"bar">>).```, use
+       * ```erlang_cassandra:set_keyspace({Host, Port, <<"bar">>}, <<"bar">>).```
+   
+*  For all the thrift commands that _don't_ take a Keyspace (e.g. ```system_update_keyspace```) you can either let the application deduce the Keyspace from the command, or you can explicitly specific it yourself.  e.g. any of the following are acceptable
+
+   * ```system_update_keyspace(KeyspaceDefinition)```
+   * ```system_update_keyspace(Keyspace, KeyspaceDefinition)``` 
+   * ```system_update_keyspace({Host, Port, Keyspace}, KeyspaceDefinition)``` 

--- a/src/external/erlang_cassandra/app.config
+++ b/src/external/erlang_cassandra/app.config
@@ -7,7 +7,7 @@
           %                ]},
           %% These options are passed to Thrift
           % {connection_options, [{thrift_host, "localhost"},
-          %                       {thrift_port, 9500},
+          %                       {thrift_port, 9160},
           %                       {thrift_options, [{framed, false}]},
           %                       {binary_response, true}
           %                ]}

--- a/src/external/erlang_cassandra/src/erlang_cassandra.app.src
+++ b/src/external/erlang_cassandra/src/erlang_cassandra.app.src
@@ -12,7 +12,7 @@
 {application, erlang_cassandra,
  [
   {description, "thrift based cassandra"},
-  {vsn, "1.0.4"},
+  {vsn, "1.0.7"},
   {registered, []},
   {modules, []},
   {applications, [
@@ -21,7 +21,7 @@
                   compiler,
                   syntax_tools,
                   sasl,
-%                  lager,
+                  lager,
                   poolboy,
                   reltool_util,
                   thrift

--- a/src/external/erlang_cassandra/src/erlang_cassandra.hrl
+++ b/src/external/erlang_cassandra/src/erlang_cassandra.hrl
@@ -65,7 +65,8 @@
 -type compression()     :: binary().
 
 %% Defaults
--define(DEFAULT_KEYSPACE, <<"default_erlang_cassandra_keyspace">>).
+-define(DUMMY_STARTUP_POOL, <<"_dummy_startup_pool">>).
+-define(DEFAULT_KEYSPACE_OPS_POOL, <<"default_keyspace_ops_pool">>).
 -define(DEFAULT_THRIFT_HOST, "localhost").
 -define(DEFAULT_THRIFT_PORT, 9160).
 -define(DEFAULT_THRIFT_OPTIONS, [{framed, true}]).
@@ -85,6 +86,7 @@
 -define(DEFAULT_SLICE_COUNT, 1000).
 
 %% Errors
+-define(INVALID_KEYSPACE, invalid_keyspace).
 -define(NO_SUCH_SEQUENCE, no_such_sequence).
 -define(CONNECTION_REFUSED, {error, econnrefused}).
 

--- a/src/external/erlang_cassandra/src/erlang_cassandra_poolboy_sup.erl
+++ b/src/external/erlang_cassandra/src/erlang_cassandra_poolboy_sup.erl
@@ -58,7 +58,7 @@ init([]) ->
 
     SupFlags = {RestartStrategy, MaxRestarts, MaxSecondsBetweenRestarts},
 
-    Keyspace = application:get_env(erlang_cassandra, keyspace, ?DEFAULT_KEYSPACE),
+    Keyspace = application:get_env(erlang_cassandra, keyspace, ?DUMMY_STARTUP_POOL),
     % We need this to be a one_for_one supervisor, because of the way the 
     % connection_options trickle through to the workers (and hence, our
     % gen-server).  To simplify things, I start a default pool of size 0. This


### PR DESCRIPTION
Obscure bug involving 'fake' keyspaces being visible
- A pool is spun up for each keyspace
- If a keyspace doesn't exist, but is 'used' (e.g. describe_..)
      then the pool is spun up
- This causes subsequent requests (after the pool is created)
      to fail, since the pool is dangling
- The solution is to use a predefined pool for all keyspace ops
      and to start this pool up if it doesn't exist

NOTE:   I couldn't actually get the tests to run - the latest develop is barfing on my laptop w/ `combonodefinder.app not found`, but that could very well be the horror that is Mavericks.
