### PR TITLE
Fix 'make install DESTDIR=pkgdir/'

### DIFF
--- a/src/AUTHORS
+++ b/src/AUTHORS
@@ -8,6 +8,7 @@ Lukas Larsson               <garazdawi [at] gmail (dot) com>
 Drew Varner                 <drew.varner [at] ninefx (dot) com>
 Irina Guberman              <irina.guberman [at] gmail (dot) com>
 Bart Van Der Meerssche      <bart [at] flukso (dot) net>
+Francisco Marchal           <marchal.francisco [at] gmail (dot) com>
 
 CloudI Integration Dependencies (alphabetical project order):
 backward-cpp     François-Xavier Bourlet <bombela@gmail.com>

--- a/src/ChangeLog
+++ b/src/ChangeLog
@@ -1,6 +1,10 @@
 # -*- coding: utf-8; tab-width: 4; -*-
 # ex: set fileencoding=utf-8 softtabstop=4 tabstop=4 expandtab:
 
+2015-05-29 Francisco Marchal   <marchal.francisco [at] gmail (dot) com>
+
+    * Fix 'make install DESTDIR=pkgdir/'
+
 2015-05-26 Michael Truog   <mjtruog [at] gmail (dot) com>
 
     * Remove the old service name paths from cloudi_service_api_requests

--- a/src/api/c/Makefile.am
+++ b/src/api/c/Makefile.am
@@ -1,7 +1,7 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
 # ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
 
-instdir = "$(DESTDIR)$(cloudi_prefix)/api/c"
+instdir = "$(cloudi_prefix)/api/c"
 inst_LTLIBRARIES = libcloudi.la
 if CXX_SUPPORT
     CXX_SUPPORT_HEADER = cloudi.hpp

--- a/src/api/python/Makefile.am
+++ b/src/api/python/Makefile.am
@@ -5,12 +5,13 @@
     python-install \
     python-c-install
 
-instdir = "$(DESTDIR)$(cloudi_prefix)/api/python"
+instdir = "$(cloudi_prefix)/api/python"
+directinstdir = "$(DESTDIR)$(cloudi_prefix)/api/python"
 
 python-install:
-	$(MKDIR_P) $(instdir)
-	$(INSTALL_DATA) $(srcdir)/erlang.py $(instdir)
-	$(INSTALL_DATA) $(srcdir)/cloudi.py $(instdir)
+	$(MKDIR_P) $(directinstdir)
+	$(INSTALL_DATA) $(srcdir)/erlang.py $(directinstdir)
+	$(INSTALL_DATA) $(srcdir)/cloudi.py $(directinstdir)
 
 if PYTHON_C_SUPPORT
 inst_LTLIBRARIES = libcloudi_py.la
@@ -36,7 +37,7 @@ PYTHON_C_INSTALL_HOOK = python-c-install
 endif
 
 python-c-install: python-install
-	$(INSTALL_DATA) $(srcdir)/cloudi_c.py $(instdir)
+	$(INSTALL_DATA) $(srcdir)/cloudi_c.py $(directinstdir)
 
 install-exec-hook: python-install $(PYTHON_C_INSTALL_HOOK)
 

--- a/src/lib/cloudi_core/cxx_src/Makefile.am
+++ b/src/lib/cloudi_core/cxx_src/Makefile.am
@@ -5,7 +5,7 @@ INTERFACE_HEADER = $(srcdir)/../src/cloudi_core_i_os_spawn.hrl
 RLIMIT_HEADER = $(srcdir)/../src/cloudi_core_i_os_rlimit.hrl
 CURRENT_VERSION = vsn_1
 
-instdir = $(DESTDIR)$(cloudi_prefix)/lib/cloudi_core-$(VERSION)/priv
+instdir = $(cloudi_prefix)/lib/cloudi_core-$(VERSION)/priv
 inst_PROGRAMS = cloudi_os_spawn_vsn_1
 inst_LTLIBRARIES = libcloudi_socket_drv.la
 

--- a/src/tests/hexpi/cxx_src/Makefile.am
+++ b/src/tests/hexpi/cxx_src/Makefile.am
@@ -1,7 +1,7 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
 # ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
 
-instdir = $(DESTDIR)$(cloudi_prefix)/tests/hexpi/priv
+instdir = $(cloudi_prefix)/tests/hexpi/priv
 inst_PROGRAMS = hexpi
 hexpi_SOURCES = assert.cpp main.cpp timer.cpp \
                 piqpr8_gmp.cpp piqpr8_gmp_verify.cpp

--- a/src/tests/hexpi/src/Makefile.am
+++ b/src/tests/hexpi/src/Makefile.am
@@ -2,7 +2,7 @@
 # ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
 
 instdir = "$(DESTDIR)$(cloudi_prefix)/tests/hexpi/ebin"
-beamdir = ../ebin
+beamdir = "$(top_builddir)/tests/hexpi/ebin"
 APPLICATION = cloudi_service_hexpi.app
 beam_DATA = cloudi_service_hexpi.beam
 CLEANFILES = $(beam_DATA) \

--- a/src/tests/http_req/c_src/Makefile.am
+++ b/src/tests/http_req/c_src/Makefile.am
@@ -1,7 +1,7 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
 # ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
 
-instdir = "$(DESTDIR)$(cloudi_prefix)/tests/http_req/priv"
+instdir = "$(cloudi_prefix)/tests/http_req/priv"
 inst_PROGRAMS = http_req
 http_req_SOURCES = main.c
 http_req_CFLAGS = -fexceptions -I$(top_srcdir)/api/c/

--- a/src/tests/http_req/src/Makefile.am
+++ b/src/tests/http_req/src/Makefile.am
@@ -2,7 +2,7 @@
 # ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
 
 instdir = "$(DESTDIR)$(cloudi_prefix)/tests/http_req/ebin"
-beamdir = ../ebin
+beamdir = "$(top_builddir)/tests/http_req/ebin"
 beam_DATA = cloudi_service_http_req.beam
 CLEANFILES = $(beam_DATA) \
              $(beamdir)/cloudi_service_http_req.beam

--- a/src/tests/messaging/cxx_src/Makefile.am
+++ b/src/tests/messaging/cxx_src/Makefile.am
@@ -1,7 +1,7 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
 # ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
 
-instdir = "$(DESTDIR)$(cloudi_prefix)/tests/messaging/priv"
+instdir = "$(cloudi_prefix)/tests/messaging/priv"
 inst_PROGRAMS = messaging
 messaging_SOURCES = assert.cpp main.cpp timer.cpp
 messaging_CPPFLAGS = -I$(top_srcdir)/api/c/ $(BOOST_CPPFLAGS)

--- a/src/tests/messaging/src/Makefile.am
+++ b/src/tests/messaging/src/Makefile.am
@@ -2,7 +2,7 @@
 # ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
 
 instdir = "$(DESTDIR)$(cloudi_prefix)/tests/messaging/ebin"
-beamdir = ../ebin
+beamdir = "$(top_builddir)/tests/messaging/ebin"
 APPLICATION = cloudi_service_messaging_sequence.app
 beam_DATA = cloudi_service_messaging_sequence1.beam \
             cloudi_service_messaging_sequence2.beam \

--- a/src/tests/msg_size/cxx_src/Makefile.am
+++ b/src/tests/msg_size/cxx_src/Makefile.am
@@ -1,7 +1,7 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
 # ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
 
-instdir = "$(DESTDIR)$(cloudi_prefix)/tests/msg_size/priv"
+instdir = "$(cloudi_prefix)/tests/msg_size/priv"
 inst_PROGRAMS = msg_size
 msg_size_SOURCES = main.cpp
 msg_size_CPPFLAGS = -I$(top_srcdir)/api/c/

--- a/src/tests/msg_size/src/Makefile.am
+++ b/src/tests/msg_size/src/Makefile.am
@@ -2,7 +2,7 @@
 # ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
 
 instdir = "$(DESTDIR)$(cloudi_prefix)/tests/msg_size/ebin"
-beamdir = ../ebin
+beamdir = "$(top_builddir)/tests/msg_size/ebin"
 beam_DATA = cloudi_service_msg_size.beam
 CLEANFILES = $(beam_DATA) \
              $(beamdir)/cloudi_service_msg_size.beam

--- a/src/tests/request_rate/src/Makefile.am
+++ b/src/tests/request_rate/src/Makefile.am
@@ -2,7 +2,7 @@
 # ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
 
 instdir = "$(DESTDIR)$(cloudi_prefix)/tests/request_rate/ebin"
-beamdir = ../ebin
+beamdir = "$(top_builddir)/tests/request_rate/ebin"
 APPLICATION = cloudi_service_request_rate.app
 beam_DATA = cloudi_service_request_rate.beam
 CLEANFILES = $(beam_DATA) \


### PR DESCRIPTION
Problem is:
Although 'make install' gives no problems, 'make install DESTDIR=mypkgdir/' installs files in bad directories inside mypkgdir/ and onto mypkgdir/../ebin.
So we can't install to some temp directory.

Why do we want to install to temp directory?:
Because distributions' tools make use of it to package software.

Bugs are:
1.- Makefile.am in some directories use "$(DESTDIR)$(cloudi_prefix)...." inside automake rules.
    Automake prefixes $(DESTDIR) to instdir automatically.
    So, final paths result in "$(DESTDIR)$(DESTDIR)$(cloudi_prefix)...."
    When DESTDIR is not used, bug is not activated, that's why 'make install' works fine.
2.- beamdir points to ../ebin, supposedly a relative path from erlang src directories, but this ../ebin seems to be used as a destination path to install relative to mypkgdir/

Solutions are:
1.- Remove $(DESTDIR) when it is passed through automake rules, not in direct make rules.
2.- Substitute ../ebin by full path where .beam binaries must be build.

Result:
Now we can make packages out of CloudI to be included by Linux distributions, maybe other OSes.

P.D:
Congratulations for a great software.