### PR TITLE
Fix vim modified flag at opening file

### DIFF
--- a/examples/hello_world1/ebin/hello_world1.app
+++ b/examples/hello_world1/ebin/hello_world1.app
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {application, hello_world1,
   [{description, "Hello World Example Application"},

--- a/examples/hello_world2/ebin/hello_world2.app
+++ b/examples/hello_world2/ebin/hello_world2.app
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {application, hello_world2,
   [{description, "Hello World Example Application"},

--- a/examples/hello_world3/apps/hello_world3/src/hello_world3.app.src
+++ b/examples/hello_world3/apps/hello_world3/src/hello_world3.app.src
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {application, hello_world3,
   [{description, "Hello World Example Application"},

--- a/examples/hello_world4/ebin/hello_world4.app
+++ b/examples/hello_world4/ebin/hello_world4.app
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {application, hello_world4,
   [{description, "Hello World Example Application"},

--- a/examples/hello_world5/apps/hello_world5/src/hello_world5.app.src
+++ b/examples/hello_world5/apps/hello_world5/src/hello_world5.app.src
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {application, hello_world5,
   [{description, "Hello World Example Application"},

--- a/examples/hello_world5/apps/hello_world5/src/hello_world5_app.erl
+++ b/examples/hello_world5/apps/hello_world5/src/hello_world5_app.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 -module(hello_world5_app).
 
 -behaviour(application).

--- a/examples/hello_world5/apps/hello_world5/src/hello_world5_sup.erl
+++ b/examples/hello_world5/apps/hello_world5/src/hello_world5_sup.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 -module(hello_world5_sup).
 
 -behaviour(supervisor).

--- a/src/ChangeLog
+++ b/src/ChangeLog
@@ -1,5 +1,9 @@
 # -*- coding: utf-8; tab-width: 4; -*-
-# ex: set fileencoding=utf-8 softtabstop=4 tabstop=4 expandtab:
+# ex: set fileencoding=utf-8 softtabstop=4 tabstop=4 expandtab nomodified:
+
+2015-06-08 Francisco Marchal   <marchal.francisco [at] gmail (dot) com>
+
+    * Fix vim modified flag at opening file
 
 2015-06-06 Michael Truog   <mjtruog [at] gmail (dot) com>
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 ACLOCAL_AMFLAGS = -I m4
 SUBDIRS = api lib tests service_api

--- a/src/api/Makefile.am
+++ b/src/api/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 if C_SUPPORT
     C_SUBDIR = c

--- a/src/api/c/Makefile.am
+++ b/src/api/c/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 instdir = "$(cloudi_prefix)/api/c"
 inst_LTLIBRARIES = libcloudi.la

--- a/src/api/c/assert.cpp
+++ b/src/api/c/assert.cpp
@@ -1,5 +1,5 @@
 //-*-Mode:C++;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/api/c/assert.hpp
+++ b/src/api/c/assert.hpp
@@ -1,5 +1,5 @@
 //-*-Mode:C++;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/api/c/cloudi.cpp
+++ b/src/api/c/cloudi.cpp
@@ -1,5 +1,5 @@
 //-*-Mode:C++;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/api/c/cloudi.h
+++ b/src/api/c/cloudi.h
@@ -1,5 +1,5 @@
 /* -*- coding: utf-8; Mode: C; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*-
- * ex: set softtabstop=4 tabstop=4 shiftwidth=4 expandtab fileencoding=utf-8:
+ * ex: set softtabstop=4 tabstop=4 shiftwidth=4 expandtab fileencoding=utf-8 nomodified:
  *
  * BSD LICENSE
  * 

--- a/src/api/c/cloudi.hpp
+++ b/src/api/c/cloudi.hpp
@@ -1,5 +1,5 @@
 //-*-Mode:C++;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/api/c/copy_ptr.hpp
+++ b/src/api/c/copy_ptr.hpp
@@ -1,5 +1,5 @@
 //-*-Mode:C++;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/api/c/realloc_ptr.hpp
+++ b/src/api/c/realloc_ptr.hpp
@@ -1,5 +1,5 @@
 //-*-Mode:C++;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/api/c/timer.cpp
+++ b/src/api/c/timer.cpp
@@ -1,5 +1,5 @@
 //-*-Mode:C++;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/api/c/timer.hpp
+++ b/src/api/c/timer.hpp
@@ -1,5 +1,5 @@
 //-*-Mode:C++;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/api/erlang/Makefile.am
+++ b/src/api/erlang/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 instdir = "$(DESTDIR)$(cloudi_prefix)/api/erlang"
 

--- a/src/api/java/Makefile.am
+++ b/src/api/java/Makefile.am
@@ -1,4 +1,4 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 SUBDIRS = com org jar

--- a/src/api/java/com/Makefile.am
+++ b/src/api/java/com/Makefile.am
@@ -1,4 +1,4 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 SUBDIRS = ericsson

--- a/src/api/java/com/ericsson/Makefile.am
+++ b/src/api/java/com/ericsson/Makefile.am
@@ -1,4 +1,4 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 SUBDIRS = otp

--- a/src/api/java/com/ericsson/otp/Makefile.am
+++ b/src/api/java/com/ericsson/otp/Makefile.am
@@ -1,4 +1,4 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 SUBDIRS = erlang

--- a/src/api/java/com/ericsson/otp/erlang/Makefile.am
+++ b/src/api/java/com/ericsson/otp/erlang/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 JAVAROOT = $(top_builddir)/api/java/jar/
 java_JAVA = AbstractConnection.java \

--- a/src/api/java/jar/Makefile.am
+++ b/src/api/java/jar/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 instdir = "$(DESTDIR)$(cloudi_prefix)/api/java"
 nodist_noinst_SCRIPTS = cloudi.jar

--- a/src/api/java/org/Makefile.am
+++ b/src/api/java/org/Makefile.am
@@ -1,4 +1,4 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 SUBDIRS = cloudi

--- a/src/api/java/org/cloudi/API.java
+++ b/src/api/java/org/cloudi/API.java
@@ -1,5 +1,5 @@
 //-*-Mode:java;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=java fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=java fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/api/java/org/cloudi/Function9.java
+++ b/src/api/java/org/cloudi/Function9.java
@@ -1,5 +1,5 @@
 //-*-Mode:java;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=java fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=java fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/api/java/org/cloudi/Makefile.am
+++ b/src/api/java/org/cloudi/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 JAVACFLAGS = -Xlint -Werror
 JAVAROOT = $(top_builddir)/api/java/jar/

--- a/src/api/javascript/CloudI.js
+++ b/src/api/javascript/CloudI.js
@@ -1,5 +1,5 @@
 //-*-Mode:javascript;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=javascript fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=javascript fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/api/javascript/Erlang.js
+++ b/src/api/javascript/Erlang.js
@@ -1,5 +1,5 @@
 //-*-Mode:javascript;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=javascript fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=javascript fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/api/javascript/Makefile.am
+++ b/src/api/javascript/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 instdir = "$(DESTDIR)$(cloudi_prefix)/api/javascript"
 

--- a/src/api/javascript/tests/ErlangTests.js
+++ b/src/api/javascript/tests/ErlangTests.js
@@ -1,5 +1,5 @@
 //-*-Mode:javascript;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=javascript fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=javascript fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/api/perl/CloudI/API.pm
+++ b/src/api/perl/CloudI/API.pm
@@ -1,5 +1,5 @@
 #-*-Mode:perl;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/api/perl/CloudI/ForwardAsyncException.pm
+++ b/src/api/perl/CloudI/ForwardAsyncException.pm
@@ -1,5 +1,5 @@
 #-*-Mode:perl;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/api/perl/CloudI/ForwardSyncException.pm
+++ b/src/api/perl/CloudI/ForwardSyncException.pm
@@ -1,5 +1,5 @@
 #-*-Mode:perl;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/api/perl/CloudI/InvalidInputException.pm
+++ b/src/api/perl/CloudI/InvalidInputException.pm
@@ -1,5 +1,5 @@
 #-*-Mode:perl;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/api/perl/CloudI/MessageDecodingException.pm
+++ b/src/api/perl/CloudI/MessageDecodingException.pm
@@ -1,5 +1,5 @@
 #-*-Mode:perl;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/api/perl/CloudI/ReturnAsyncException.pm
+++ b/src/api/perl/CloudI/ReturnAsyncException.pm
@@ -1,5 +1,5 @@
 #-*-Mode:perl;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/api/perl/CloudI/ReturnSyncException.pm
+++ b/src/api/perl/CloudI/ReturnSyncException.pm
@@ -1,5 +1,5 @@
 #-*-Mode:perl;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/api/perl/CloudI/TerminateException.pm
+++ b/src/api/perl/CloudI/TerminateException.pm
@@ -1,5 +1,5 @@
 #-*-Mode:perl;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/api/perl/Erlang.pm
+++ b/src/api/perl/Erlang.pm
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 #-*-Mode:perl;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/api/perl/Erlang/Exception.pm
+++ b/src/api/perl/Erlang/Exception.pm
@@ -1,5 +1,5 @@
 #-*-Mode:perl;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/api/perl/Erlang/InputException.pm
+++ b/src/api/perl/Erlang/InputException.pm
@@ -1,5 +1,5 @@
 #-*-Mode:perl;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/api/perl/Erlang/OtpErlangAtom.pm
+++ b/src/api/perl/Erlang/OtpErlangAtom.pm
@@ -1,5 +1,5 @@
 #-*-Mode:perl;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/api/perl/Erlang/OtpErlangBinary.pm
+++ b/src/api/perl/Erlang/OtpErlangBinary.pm
@@ -1,5 +1,5 @@
 #-*-Mode:perl;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/api/perl/Erlang/OtpErlangFunction.pm
+++ b/src/api/perl/Erlang/OtpErlangFunction.pm
@@ -1,5 +1,5 @@
 #-*-Mode:perl;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/api/perl/Erlang/OtpErlangList.pm
+++ b/src/api/perl/Erlang/OtpErlangList.pm
@@ -1,5 +1,5 @@
 #-*-Mode:perl;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/api/perl/Erlang/OtpErlangPid.pm
+++ b/src/api/perl/Erlang/OtpErlangPid.pm
@@ -1,5 +1,5 @@
 #-*-Mode:perl;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/api/perl/Erlang/OtpErlangPort.pm
+++ b/src/api/perl/Erlang/OtpErlangPort.pm
@@ -1,5 +1,5 @@
 #-*-Mode:perl;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/api/perl/Erlang/OtpErlangReference.pm
+++ b/src/api/perl/Erlang/OtpErlangReference.pm
@@ -1,5 +1,5 @@
 #-*-Mode:perl;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/api/perl/Erlang/OtpErlangString.pm
+++ b/src/api/perl/Erlang/OtpErlangString.pm
@@ -1,5 +1,5 @@
 #-*-Mode:perl;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/api/perl/Erlang/OutputException.pm
+++ b/src/api/perl/Erlang/OutputException.pm
@@ -1,5 +1,5 @@
 #-*-Mode:perl;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/api/perl/Erlang/ParseException.pm
+++ b/src/api/perl/Erlang/ParseException.pm
@@ -1,5 +1,5 @@
 #-*-Mode:perl;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/api/perl/Makefile.am
+++ b/src/api/perl/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 instdir = "$(DESTDIR)$(cloudi_prefix)/api/perl"
 

--- a/src/api/php/CloudI.php
+++ b/src/api/php/CloudI.php
@@ -1,5 +1,5 @@
 <?php //-*-coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=php fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=php fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/api/php/Erlang.php
+++ b/src/api/php/Erlang.php
@@ -1,5 +1,5 @@
 <?php //-*-coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=php fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=php fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/api/php/Makefile.am
+++ b/src/api/php/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 instdir = "$(DESTDIR)$(cloudi_prefix)/api/php"
 

--- a/src/api/php/tests/ErlangTests.php
+++ b/src/api/php/tests/ErlangTests.php
@@ -1,5 +1,5 @@
 <?php //-*-coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=php fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=php fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/api/python/Makefile.am
+++ b/src/api/python/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 .PHONY: \
     python-install \

--- a/src/api/python/cloudi.py
+++ b/src/api/python/cloudi.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #-*-Mode:python;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=python fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=python fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/api/python/cloudi_c.py
+++ b/src/api/python/cloudi_c.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #-*-Mode:python;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=python fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=python fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/api/python/cloudi_py.cpp
+++ b/src/api/python/cloudi_py.cpp
@@ -1,5 +1,5 @@
 /* -*- coding: utf-8; Mode: C; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*-
- * ex: set softtabstop=4 tabstop=4 shiftwidth=4 expandtab fileencoding=utf-8:
+ * ex: set softtabstop=4 tabstop=4 shiftwidth=4 expandtab fileencoding=utf-8 nomodified:
  *
  * BSD LICENSE
  * 

--- a/src/api/python/erlang.py
+++ b/src/api/python/erlang.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #-*-Mode:python;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=python fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=python fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/api/python/tests/erlang_tests.py
+++ b/src/api/python/tests/erlang_tests.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #-*-Mode:python;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=python fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=python fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/api/ruby/Makefile.am
+++ b/src/api/ruby/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 instdir = "$(DESTDIR)$(cloudi_prefix)/api/ruby"
 

--- a/src/api/ruby/cloudi.rb
+++ b/src/api/ruby/cloudi.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 #-*-Mode:ruby;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=ruby fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=ruby fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/api/ruby/erlang.rb
+++ b/src/api/ruby/erlang.rb
@@ -1,5 +1,5 @@
 #-*-Mode:ruby;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=ruby fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=ruby fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/api/ruby/tests/erlang_tests.rb
+++ b/src/api/ruby/tests/erlang_tests.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 #-*-Mode:ruby;coding:binary;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=ruby fenc=binary sts=4 ts=4 sw=4 et:
+# ex: set ft=ruby fenc=binary sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1,5 +1,5 @@
 #-*-Mode:autoconf;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=config fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=config fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 AC_INIT([CloudI], [1.5.0], [mjtruog at gmail dot com],
         [cloudi], [http://cloudi.org/])

--- a/src/external/booster/lib/backtrace/test/config.h
+++ b/src/external/booster/lib/backtrace/test/config.h
@@ -1,5 +1,5 @@
 //-*-Mode:C++;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #ifndef CONFIG_H
 #define CONFIG_H
 

--- a/src/external/cloudi_x_nodefinder/src/nodefinder.app.src
+++ b/src/external/cloudi_x_nodefinder/src/nodefinder.app.src
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {application, nodefinder, 
   [{description, "nodefinder Application"},

--- a/src/external/cloudi_x_nodefinder/src/nodefinder.erl
+++ b/src/external/cloudi_x_nodefinder/src/nodefinder.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 -module(nodefinder).
 

--- a/src/external/cloudi_x_nodefinder/src/nodefinder_app.erl
+++ b/src/external/cloudi_x_nodefinder/src/nodefinder_app.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %% @doc nodefinder Application.
 %% @end
 

--- a/src/external/cloudi_x_nodefinder/src/nodefinder_ec2.erl
+++ b/src/external/cloudi_x_nodefinder/src/nodefinder_ec2.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %% @doc EC2 Erlang node discovery.
 %% @end
 

--- a/src/external/cloudi_x_nodefinder/src/nodefinder_multicast.erl
+++ b/src/external/cloudi_x_nodefinder/src/nodefinder_multicast.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %% @doc Multicast Erlang node discovery protocol.
 %% Listens on a multicast channel for node discovery requests and 
 %% responds by connecting to the node.

--- a/src/external/cloudi_x_nodefinder/src/nodefinder_sup.erl
+++ b/src/external/cloudi_x_nodefinder/src/nodefinder_sup.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 -module(nodefinder_sup).
 

--- a/src/external/rebar_modules/src/protobuffs_compile.erl
+++ b/src/external/rebar_modules/src/protobuffs_compile.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 -module(protobuffs_compile).
 -export([scan_file/2]).
 

--- a/src/external/zeromq/v2/erlzmq/c_src/erlzmq_nif.c
+++ b/src/external/zeromq/v2/erlzmq/c_src/erlzmq_nif.c
@@ -1,5 +1,5 @@
 // -*- coding:utf-8;Mode:C;tab-width:2;c-basic-offset:2;indent-tabs-mode:nil -*-
-// ex: set softtabstop=2 tabstop=2 shiftwidth=2 expandtab fileencoding=utf-8:
+// ex: set softtabstop=2 tabstop=2 shiftwidth=2 expandtab fileencoding=utf-8 nomodified:
 //
 // Copyright (c) 2011 Yurii Rashkovskii, Evax Software and Michael Truog
 // 

--- a/src/external/zeromq/v2/erlzmq/c_src/vector.c
+++ b/src/external/zeromq/v2/erlzmq/c_src/vector.c
@@ -1,5 +1,5 @@
 /* -*- coding: utf-8; Mode: C; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*-
- * ex: set softtabstop=4 tabstop=4 shiftwidth=4 expandtab fileencoding=utf-8:
+ * ex: set softtabstop=4 tabstop=4 shiftwidth=4 expandtab fileencoding=utf-8 nomodified:
  *
  * BSD LICENSE
  * 

--- a/src/external/zeromq/v2/erlzmq/c_src/vector.h
+++ b/src/external/zeromq/v2/erlzmq/c_src/vector.h
@@ -1,5 +1,5 @@
 /* -*- coding: utf-8; Mode: C; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*-
- * ex: set softtabstop=4 tabstop=4 shiftwidth=4 expandtab fileencoding=utf-8:
+ * ex: set softtabstop=4 tabstop=4 shiftwidth=4 expandtab fileencoding=utf-8 nomodified:
  *
  * BSD LICENSE
  * 

--- a/src/external/zeromq/v2/erlzmq/src/erlzmq.erl
+++ b/src/external/zeromq/v2/erlzmq/src/erlzmq.erl
@@ -1,5 +1,5 @@
 %% -*- coding:utf-8;Mode:erlang;tab-width:4;c-basic-offset:4;indent-tabs-mode:nil -*-
-%% ex: set softtabstop=4 tabstop=4 shiftwidth=4 expandtab fileencoding=utf-8:
+%% ex: set softtabstop=4 tabstop=4 shiftwidth=4 expandtab fileencoding=utf-8 nomodified:
 %%
 %% Copyright (c) 2011 Yurii Rashkovskii, Evax Software and Michael Truog
 %% 

--- a/src/external/zeromq/v3/erlzmq/c_src/erlzmq_nif.c
+++ b/src/external/zeromq/v3/erlzmq/c_src/erlzmq_nif.c
@@ -1,5 +1,5 @@
 // -*- coding:utf-8;Mode:C;tab-width:2;c-basic-offset:2;indent-tabs-mode:nil -*-
-// ex: set softtabstop=2 tabstop=2 shiftwidth=2 expandtab fileencoding=utf-8:
+// ex: set softtabstop=2 tabstop=2 shiftwidth=2 expandtab fileencoding=utf-8 nomodified:
 //
 // Copyright (c) 2011 Yurii Rashkovskii, Evax Software and Michael Truog
 //

--- a/src/external/zeromq/v3/erlzmq/c_src/vector.c
+++ b/src/external/zeromq/v3/erlzmq/c_src/vector.c
@@ -1,5 +1,5 @@
 /* -*- coding: utf-8; Mode: C; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*-
- * ex: set softtabstop=4 tabstop=4 shiftwidth=4 expandtab fileencoding=utf-8:
+ * ex: set softtabstop=4 tabstop=4 shiftwidth=4 expandtab fileencoding=utf-8 nomodified:
  *
  * BSD LICENSE
  *

--- a/src/external/zeromq/v3/erlzmq/c_src/vector.h
+++ b/src/external/zeromq/v3/erlzmq/c_src/vector.h
@@ -1,5 +1,5 @@
 /* -*- coding: utf-8; Mode: C; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*-
- * ex: set softtabstop=4 tabstop=4 shiftwidth=4 expandtab fileencoding=utf-8:
+ * ex: set softtabstop=4 tabstop=4 shiftwidth=4 expandtab fileencoding=utf-8 nomodified:
  *
  * BSD LICENSE
  *

--- a/src/external/zeromq/v3/erlzmq/src/erlzmq.erl
+++ b/src/external/zeromq/v3/erlzmq/src/erlzmq.erl
@@ -1,5 +1,5 @@
 %% -*- coding:utf-8;Mode:erlang;tab-width:4;c-basic-offset:4;indent-tabs-mode:nil -*-
-%% ex: set softtabstop=4 tabstop=4 shiftwidth=4 expandtab fileencoding=utf-8:
+%% ex: set softtabstop=4 tabstop=4 shiftwidth=4 expandtab fileencoding=utf-8 nomodified:
 %%
 %% Copyright (c) 2011 Yurii Rashkovskii, Evax Software and Michael Truog
 %%

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -1,4 +1,4 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 SUBDIRS = cloudi_core

--- a/src/lib/cloudi_core/Makefile.am
+++ b/src/lib/cloudi_core/Makefile.am
@@ -1,4 +1,4 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 SUBDIRS = cxx_src

--- a/src/lib/cloudi_core/cxx_src/Makefile.am
+++ b/src/lib/cloudi_core/cxx_src/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 INTERFACE_HEADER = $(srcdir)/../src/cloudi_core_i_os_spawn.hrl
 RLIMIT_HEADER = $(srcdir)/../src/cloudi_core_i_os_rlimit.hrl

--- a/src/lib/cloudi_core/cxx_src/assert.cpp
+++ b/src/lib/cloudi_core/cxx_src/assert.cpp
@@ -1,5 +1,5 @@
 //-*-Mode:C++;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/lib/cloudi_core/cxx_src/assert.hpp
+++ b/src/lib/cloudi_core/cxx_src/assert.hpp
@@ -1,5 +1,5 @@
 //-*-Mode:C++;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/lib/cloudi_core/cxx_src/cloudi_os_owner.cpp
+++ b/src/lib/cloudi_core/cxx_src/cloudi_os_owner.cpp
@@ -1,5 +1,5 @@
 //-*-Mode:C++;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/lib/cloudi_core/cxx_src/cloudi_os_owner.hpp
+++ b/src/lib/cloudi_core/cxx_src/cloudi_os_owner.hpp
@@ -1,5 +1,5 @@
 //-*-Mode:C++;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/lib/cloudi_core/cxx_src/cloudi_os_rlimit.cpp
+++ b/src/lib/cloudi_core/cxx_src/cloudi_os_rlimit.cpp
@@ -1,5 +1,5 @@
 //-*-Mode:C++;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/lib/cloudi_core/cxx_src/cloudi_os_rlimit.hpp
+++ b/src/lib/cloudi_core/cxx_src/cloudi_os_rlimit.hpp
@@ -1,5 +1,5 @@
 //-*-Mode:C++;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/lib/cloudi_core/cxx_src/cloudi_os_spawn.cpp
+++ b/src/lib/cloudi_core/cxx_src/cloudi_os_spawn.cpp
@@ -1,5 +1,5 @@
 //-*-Mode:C++;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/lib/cloudi_core/cxx_src/cloudi_os_spawn.hpp
+++ b/src/lib/cloudi_core/cxx_src/cloudi_os_spawn.hpp
@@ -1,5 +1,5 @@
 //-*-Mode:C++;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/lib/cloudi_core/cxx_src/cloudi_socket_drv.cpp
+++ b/src/lib/cloudi_core/cxx_src/cloudi_socket_drv.cpp
@@ -1,5 +1,5 @@
 //-*-Mode:C++;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/lib/cloudi_core/cxx_src/copy_ptr.hpp
+++ b/src/lib/cloudi_core/cxx_src/copy_ptr.hpp
@@ -1,5 +1,5 @@
 //-*-Mode:C++;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/lib/cloudi_core/cxx_src/realloc_ptr.hpp
+++ b/src/lib/cloudi_core/cxx_src/realloc_ptr.hpp
@@ -1,5 +1,5 @@
 //-*-Mode:C++;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/lib/cloudi_core/include/CloudILogger.ex
+++ b/src/lib/cloudi_core/include/CloudILogger.ex
@@ -1,5 +1,5 @@
 #-*-Mode:ruby;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=ruby fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=ruby fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 ###
 ###------------------------------------------------------------------------
 ###

--- a/src/lib/cloudi_core/include/cloudi_logger.hrl
+++ b/src/lib/cloudi_core/include/cloudi_logger.hrl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%%

--- a/src/lib/cloudi_core/include/cloudi_service.hrl
+++ b/src/lib/cloudi_core/include/cloudi_service.hrl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%%

--- a/src/lib/cloudi_core/include/cloudi_service_api.hrl
+++ b/src/lib/cloudi_core/include/cloudi_service_api.hrl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%%

--- a/src/lib/cloudi_core/include/cloudi_service_children.hrl
+++ b/src/lib/cloudi_core/include/cloudi_service_children.hrl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%%

--- a/src/lib/cloudi_core/rebar.config
+++ b/src/lib/cloudi_core/rebar.config
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {lib_dirs,
  ["..",

--- a/src/lib/cloudi_core/scripts/mimetypes_update
+++ b/src/lib/cloudi_core/scripts/mimetypes_update
@@ -1,7 +1,7 @@
 #!/usr/bin/env escript
 %%!
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 % execute the script in its directory for the hard-coded output path
 

--- a/src/lib/cloudi_core/src/cloudi.erl
+++ b/src/lib/cloudi_core/src/cloudi.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_concurrency.erl
+++ b/src/lib/cloudi_core/src/cloudi_concurrency.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_core.app.src.in
+++ b/src/lib/cloudi_core/src/cloudi_core.app.src.in
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {application, cloudi_core, 
   [{description, "CloudI Core Application"},

--- a/src/lib/cloudi_core/src/cloudi_core_i_app.erl
+++ b/src/lib/cloudi_core/src/cloudi_core_i_app.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_core_i_configuration.erl
+++ b/src/lib/cloudi_core/src/cloudi_core_i_configuration.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_core_i_configuration.hrl
+++ b/src/lib/cloudi_core/src/cloudi_core_i_configuration.hrl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%%

--- a/src/lib/cloudi_core/src/cloudi_core_i_configuration_defaults.hrl
+++ b/src/lib/cloudi_core/src/cloudi_core_i_configuration_defaults.hrl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%%

--- a/src/lib/cloudi_core/src/cloudi_core_i_configurator.erl
+++ b/src/lib/cloudi_core/src/cloudi_core_i_configurator.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_core_i_logger.erl
+++ b/src/lib/cloudi_core/src/cloudi_core_i_logger.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_core_i_logger_interface.erl
+++ b/src/lib/cloudi_core/src/cloudi_core_i_logger_interface.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_core_i_logger_output.erl
+++ b/src/lib/cloudi_core/src/cloudi_core_i_logger_output.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_core_i_logger_output_sup.erl
+++ b/src/lib/cloudi_core/src/cloudi_core_i_logger_output_sup.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_core_i_logger_sup.erl
+++ b/src/lib/cloudi_core/src/cloudi_core_i_logger_sup.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_core_i_nodes.erl
+++ b/src/lib/cloudi_core/src/cloudi_core_i_nodes.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_core_i_os_process.erl
+++ b/src/lib/cloudi_core/src/cloudi_core_i_os_process.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_core_i_os_spawn.erl
+++ b/src/lib/cloudi_core/src/cloudi_core_i_os_spawn.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_core_i_pool.erl
+++ b/src/lib/cloudi_core/src/cloudi_core_i_pool.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_core_i_pool_sup.erl
+++ b/src/lib/cloudi_core/src/cloudi_core_i_pool_sup.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_core_i_rate_based_configuration.erl
+++ b/src/lib/cloudi_core/src/cloudi_core_i_rate_based_configuration.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_core_i_runtime_testing.erl
+++ b/src/lib/cloudi_core/src/cloudi_core_i_runtime_testing.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_core_i_services_common.hrl
+++ b/src/lib/cloudi_core/src/cloudi_core_i_services_common.hrl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% CloudI Services Fuctions Common to Both Internal and External Services

--- a/src/lib/cloudi_core/src/cloudi_core_i_services_external.erl
+++ b/src/lib/cloudi_core/src/cloudi_core_i_services_external.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_core_i_services_external_sup.erl
+++ b/src/lib/cloudi_core/src/cloudi_core_i_services_external_sup.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_core_i_services_internal.erl
+++ b/src/lib/cloudi_core/src/cloudi_core_i_services_internal.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_core_i_services_internal_init.erl
+++ b/src/lib/cloudi_core/src/cloudi_core_i_services_internal_init.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_core_i_services_internal_reload.erl
+++ b/src/lib/cloudi_core/src/cloudi_core_i_services_internal_reload.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_core_i_services_internal_sup.erl
+++ b/src/lib/cloudi_core/src/cloudi_core_i_services_internal_sup.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_core_i_services_monitor.erl
+++ b/src/lib/cloudi_core/src/cloudi_core_i_services_monitor.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_core_i_socket.erl
+++ b/src/lib/cloudi_core/src/cloudi_core_i_socket.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_core_i_spawn.erl
+++ b/src/lib/cloudi_core/src/cloudi_core_i_spawn.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_core_i_sup.erl
+++ b/src/lib/cloudi_core/src/cloudi_core_i_sup.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_core_i_sup.erl
+++ b/src/lib/cloudi_core/src/cloudi_core_i_sup.erl
@@ -140,7 +140,7 @@ child_specification(cloudi_core_i_logger, Config) ->
     Shutdown = 2000, % milliseconds
     {cloudi_core_i_logger,
      {cloudi_core_i_logger, start_link, [Config]},
-     permanent, Shutdown, worker, [cloud_core_i_logger]};
+     permanent, Shutdown, worker, [cloudi_core_i_logger]};
 
 child_specification(cloudi_core_i_nodes, Config) ->
     Shutdown = 2000, % milliseconds
@@ -152,7 +152,7 @@ child_specification(cloudi_core_i_configurator, Config) ->
     Shutdown = 2000, % milliseconds
     {cloudi_core_i_configurator,
      {cloudi_core_i_configurator, start_link, [Config]},
-     permanent, Shutdown, worker, [cloud_core_i_configurator]}.
+     permanent, Shutdown, worker, [cloudi_core_i_configurator]}.
 
 child_specification(cloudi_core_i_services_monitor) ->
     Shutdown = 2000, % milliseconds

--- a/src/lib/cloudi_core/src/cloudi_environment.erl
+++ b/src/lib/cloudi_core/src/cloudi_environment.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_future.erl
+++ b/src/lib/cloudi_core/src/cloudi_future.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_ip_address.erl
+++ b/src/lib/cloudi_core/src/cloudi_ip_address.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_key_value.erl
+++ b/src/lib/cloudi_core/src/cloudi_key_value.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_lists.erl
+++ b/src/lib/cloudi_core/src/cloudi_lists.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_math.erl
+++ b/src/lib/cloudi_core/src/cloudi_math.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_proplists.erl
+++ b/src/lib/cloudi_core/src/cloudi_proplists.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_queue.erl
+++ b/src/lib/cloudi_core/src/cloudi_queue.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_request.erl
+++ b/src/lib/cloudi_core/src/cloudi_request.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_request_info.erl
+++ b/src/lib/cloudi_core/src/cloudi_request_info.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_response.erl
+++ b/src/lib/cloudi_core/src/cloudi_response.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_response_info.erl
+++ b/src/lib/cloudi_core/src/cloudi_response_info.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_service.erl
+++ b/src/lib/cloudi_core/src/cloudi_service.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_service_api.erl
+++ b/src/lib/cloudi_core/src/cloudi_service_api.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_service_future.erl
+++ b/src/lib/cloudi_core/src/cloudi_service_future.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_service_name.erl
+++ b/src/lib/cloudi_core/src/cloudi_service_name.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_string.erl
+++ b/src/lib/cloudi_core/src/cloudi_string.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/src/cloudi_timestamp.erl
+++ b/src/lib/cloudi_core/src/cloudi_timestamp.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_core/test_ct/cloudi_service_SUITE.erl
+++ b/src/lib/cloudi_core/test_ct/cloudi_service_SUITE.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%------------------------------------------------------------------------
 %%% @doc
 %%% ==CloudI Core Basic Tests==

--- a/src/lib/cloudi_service_api_requests/src/cloudi_json_rpc.erl
+++ b/src/lib/cloudi_service_api_requests/src/cloudi_json_rpc.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_service_api_requests/src/cloudi_service_api_requests.app.src.in
+++ b/src/lib/cloudi_service_api_requests/src/cloudi_service_api_requests.app.src.in
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {application, cloudi_service_api_requests, 
   [{description, "CloudI Service API Service"},

--- a/src/lib/cloudi_service_api_requests/src/cloudi_service_api_requests.erl
+++ b/src/lib/cloudi_service_api_requests/src/cloudi_service_api_requests.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_service_db/src/cloudi_service_db.app.src.in
+++ b/src/lib/cloudi_service_db/src/cloudi_service_db.app.src.in
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {application, cloudi_service_db, 
   [{description, "CloudI Database (in-memory/testing/generic)"},

--- a/src/lib/cloudi_service_db/src/cloudi_service_db.erl
+++ b/src/lib/cloudi_service_db/src/cloudi_service_db.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_service_db_cassandra/rebar.config
+++ b/src/lib/cloudi_service_db_cassandra/rebar.config
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {lib_dirs,
  ["..",

--- a/src/lib/cloudi_service_db_cassandra/src/cloudi_service_db_cassandra.app.src.in
+++ b/src/lib/cloudi_service_db_cassandra/src/cloudi_service_db_cassandra.app.src.in
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {application, cloudi_service_db_cassandra, 
   [{description, "Cassandra CloudI Service"},

--- a/src/lib/cloudi_service_db_cassandra/src/cloudi_service_db_cassandra.erl
+++ b/src/lib/cloudi_service_db_cassandra/src/cloudi_service_db_cassandra.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_service_db_cassandra_cql/rebar.config
+++ b/src/lib/cloudi_service_db_cassandra_cql/rebar.config
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {lib_dirs,
  ["..",

--- a/src/lib/cloudi_service_db_cassandra_cql/src/cloudi_service_db_cassandra_cql.app.src
+++ b/src/lib/cloudi_service_db_cassandra_cql/src/cloudi_service_db_cassandra_cql.app.src
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {application, cloudi_service_db_cassandra_cql,
   [{description, "DB Cassandra CQL CloudI Service"},

--- a/src/lib/cloudi_service_db_cassandra_cql/src/cloudi_service_db_cassandra_cql.erl
+++ b/src/lib/cloudi_service_db_cassandra_cql/src/cloudi_service_db_cassandra_cql.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_service_db_couchdb/src/cloudi_service_db_couchdb.app.src.in
+++ b/src/lib/cloudi_service_db_couchdb/src/cloudi_service_db_couchdb.app.src.in
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {application, cloudi_service_db_couchdb, 
   [{description, "CouchDB CloudI Service"},

--- a/src/lib/cloudi_service_db_couchdb/src/cloudi_service_db_couchdb.erl
+++ b/src/lib/cloudi_service_db_couchdb/src/cloudi_service_db_couchdb.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_service_db_elasticsearch/rebar.config
+++ b/src/lib/cloudi_service_db_elasticsearch/rebar.config
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {lib_dirs,
  ["..",

--- a/src/lib/cloudi_service_db_elasticsearch/src/cloudi_service_db_elasticsearch.app.src.in
+++ b/src/lib/cloudi_service_db_elasticsearch/src/cloudi_service_db_elasticsearch.app.src.in
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {application, cloudi_service_db_elasticsearch, 
   [{description, "elasticsearch CloudI Service"},

--- a/src/lib/cloudi_service_db_elasticsearch/src/cloudi_service_db_elasticsearch.erl
+++ b/src/lib/cloudi_service_db_elasticsearch/src/cloudi_service_db_elasticsearch.erl
@@ -1,5 +1,5 @@
 %%% -*- coding: utf-8; Mode: erlang; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*-
-%%% ex: set softtabstop=4 tabstop=4 shiftwidth=4 expandtab fileencoding=utf-8:
+%%% ex: set softtabstop=4 tabstop=4 shiftwidth=4 expandtab fileencoding=utf-8 nomodified:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_service_db_memcached/src/cloudi_service_db_memcached.app.src.in
+++ b/src/lib/cloudi_service_db_memcached/src/cloudi_service_db_memcached.app.src.in
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {application, cloudi_service_db_memcached, 
   [{description, "memcached CloudI Service"},

--- a/src/lib/cloudi_service_db_memcached/src/cloudi_service_db_memcached.erl
+++ b/src/lib/cloudi_service_db_memcached/src/cloudi_service_db_memcached.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_service_db_mysql/rebar.config
+++ b/src/lib/cloudi_service_db_mysql/rebar.config
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {lib_dirs,
  ["..",

--- a/src/lib/cloudi_service_db_mysql/src/cloudi_service_db_mysql.app.src.in
+++ b/src/lib/cloudi_service_db_mysql/src/cloudi_service_db_mysql.app.src.in
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {application, cloudi_service_db_mysql, 
   [{description, "MySQL CloudI Service"},

--- a/src/lib/cloudi_service_db_mysql/src/cloudi_service_db_mysql.erl
+++ b/src/lib/cloudi_service_db_mysql/src/cloudi_service_db_mysql.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_service_db_mysql/test_ct/cloudi_service_db_mysql_SUITE.erl
+++ b/src/lib/cloudi_service_db_mysql/test_ct/cloudi_service_db_mysql_SUITE.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 -module(cloudi_service_db_mysql_SUITE).
 
 %% CT callbacks

--- a/src/lib/cloudi_service_db_pgsql/rebar.config
+++ b/src/lib/cloudi_service_db_pgsql/rebar.config
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {lib_dirs,
  ["..",

--- a/src/lib/cloudi_service_db_pgsql/src/cloudi_service_db_pgsql.app.src.in
+++ b/src/lib/cloudi_service_db_pgsql/src/cloudi_service_db_pgsql.app.src.in
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {application, cloudi_service_db_pgsql, 
   [{description, "PostgreSQL CloudI Service"},

--- a/src/lib/cloudi_service_db_pgsql/src/cloudi_service_db_pgsql.erl
+++ b/src/lib/cloudi_service_db_pgsql/src/cloudi_service_db_pgsql.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_service_db_pgsql/test_ct/cloudi_service_db_pgsql_SUITE.erl
+++ b/src/lib/cloudi_service_db_pgsql/test_ct/cloudi_service_db_pgsql_SUITE.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 -module(cloudi_service_db_pgsql_SUITE).
 
 %% CT callbacks

--- a/src/lib/cloudi_service_db_riak/rebar.config
+++ b/src/lib/cloudi_service_db_riak/rebar.config
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {lib_dirs,
  ["..",

--- a/src/lib/cloudi_service_db_riak/src/cloudi_service_db_riak.erl
+++ b/src/lib/cloudi_service_db_riak/src/cloudi_service_db_riak.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_service_db_riak/test_ct/cloudi_service_db_riak_SUITE.erl
+++ b/src/lib/cloudi_service_db_riak/test_ct/cloudi_service_db_riak_SUITE.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 -module(cloudi_service_db_riak_SUITE).
 
 %% CT callbacks

--- a/src/lib/cloudi_service_db_tokyotyrant/src/cloudi_service_db_tokyotyrant.app.src.in
+++ b/src/lib/cloudi_service_db_tokyotyrant/src/cloudi_service_db_tokyotyrant.app.src.in
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {application, cloudi_service_db_tokyotyrant, 
   [{description, "Tokyo Tyrant CloudI Service"},

--- a/src/lib/cloudi_service_db_tokyotyrant/src/cloudi_service_db_tokyotyrant.erl
+++ b/src/lib/cloudi_service_db_tokyotyrant/src/cloudi_service_db_tokyotyrant.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_service_filesystem/rebar.config
+++ b/src/lib/cloudi_service_filesystem/rebar.config
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {lib_dirs,
  ["..",

--- a/src/lib/cloudi_service_filesystem/src/cloudi_service_filesystem.app.src.in
+++ b/src/lib/cloudi_service_filesystem/src/cloudi_service_filesystem.app.src.in
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {application, cloudi_service_filesystem, 
   [{description, "Filesystem CloudI Service"},

--- a/src/lib/cloudi_service_filesystem/src/cloudi_service_filesystem.erl
+++ b/src/lib/cloudi_service_filesystem/src/cloudi_service_filesystem.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_service_filesystem/src/cloudi_service_filesystem_parse.erl
+++ b/src/lib/cloudi_service_filesystem/src/cloudi_service_filesystem_parse.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_service_filesystem/test_ct/cloudi_service_filesystem_SUITE.erl
+++ b/src/lib/cloudi_service_filesystem/test_ct/cloudi_service_filesystem_SUITE.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%------------------------------------------------------------------------
 %%% @doc
 %%% ==CloudI Service Filesystem Tests==

--- a/src/lib/cloudi_service_http_client/rebar.config
+++ b/src/lib/cloudi_service_http_client/rebar.config
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {lib_dirs,
  ["..",

--- a/src/lib/cloudi_service_http_client/src/cloudi_service_http_client.app.src.in
+++ b/src/lib/cloudi_service_http_client/src/cloudi_service_http_client.app.src.in
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {application, cloudi_service_http_client, 
   [{description, "HTTP client CloudI Service"},

--- a/src/lib/cloudi_service_http_client/src/cloudi_service_http_client.erl
+++ b/src/lib/cloudi_service_http_client/src/cloudi_service_http_client.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_service_http_client/test_ct/cloudi_service_http_client_SUITE.erl
+++ b/src/lib/cloudi_service_http_client/test_ct/cloudi_service_http_client_SUITE.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 -module(cloudi_service_http_client_SUITE).
 
 %% CT callbacks

--- a/src/lib/cloudi_service_http_cowboy/src/cloudi_http_cowboy_handler.erl
+++ b/src/lib/cloudi_service_http_cowboy/src/cloudi_http_cowboy_handler.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_service_http_cowboy/src/cloudi_http_cowboy_handler.hrl
+++ b/src/lib/cloudi_service_http_cowboy/src/cloudi_http_cowboy_handler.hrl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%%

--- a/src/lib/cloudi_service_http_cowboy/src/cloudi_service_http_cowboy.app.src.in
+++ b/src/lib/cloudi_service_http_cowboy/src/cloudi_service_http_cowboy.app.src.in
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {application, cloudi_service_http_cowboy, 
   [{description, "cowboy HTTP CloudI Service"},

--- a/src/lib/cloudi_service_http_cowboy/src/cloudi_service_http_cowboy.erl
+++ b/src/lib/cloudi_service_http_cowboy/src/cloudi_service_http_cowboy.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_service_http_elli/src/cloudi_http_elli_handler.erl
+++ b/src/lib/cloudi_service_http_elli/src/cloudi_http_elli_handler.erl
@@ -1,5 +1,5 @@
 %%% -*- coding: utf-8; Mode: erlang; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*-
-%%% ex: set softtabstop=4 tabstop=4 shiftwidth=4 expandtab fileencoding=utf-8:
+%%% ex: set softtabstop=4 tabstop=4 shiftwidth=4 expandtab fileencoding=utf-8 nomodified:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_service_http_elli/src/cloudi_http_elli_handler.hrl
+++ b/src/lib/cloudi_service_http_elli/src/cloudi_http_elli_handler.hrl
@@ -1,5 +1,5 @@
 %%% -*- coding: utf-8; Mode: erlang; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*-
-%%% ex: set softtabstop=4 tabstop=4 shiftwidth=4 expandtab fileencoding=utf-8:
+%%% ex: set softtabstop=4 tabstop=4 shiftwidth=4 expandtab fileencoding=utf-8 nomodified:
 %%%
 %%%------------------------------------------------------------------------
 %%%

--- a/src/lib/cloudi_service_http_elli/src/cloudi_service_http_elli.app.src.in
+++ b/src/lib/cloudi_service_http_elli/src/cloudi_service_http_elli.app.src.in
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {application, cloudi_service_http_elli, 
   [{description, "elli HTTP CloudI Service"},

--- a/src/lib/cloudi_service_http_elli/src/cloudi_service_http_elli.erl
+++ b/src/lib/cloudi_service_http_elli/src/cloudi_service_http_elli.erl
@@ -1,5 +1,5 @@
 %%% -*- coding: utf-8; Mode: erlang; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*-
-%%% ex: set softtabstop=4 tabstop=4 shiftwidth=4 expandtab fileencoding=utf-8:
+%%% ex: set softtabstop=4 tabstop=4 shiftwidth=4 expandtab fileencoding=utf-8 nomodified:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_service_map_reduce/src/cloudi_service_map_reduce.app.src.in
+++ b/src/lib/cloudi_service_map_reduce/src/cloudi_service_map_reduce.app.src.in
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {application, cloudi_service_map_reduce, 
   [{description, "Map/Reduce CloudI Service"},

--- a/src/lib/cloudi_service_map_reduce/src/cloudi_service_map_reduce.erl
+++ b/src/lib/cloudi_service_map_reduce/src/cloudi_service_map_reduce.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_service_map_reduce/src/cloudi_task_size.erl
+++ b/src/lib/cloudi_service_map_reduce/src/cloudi_task_size.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_service_oauth1/rebar.config
+++ b/src/lib/cloudi_service_oauth1/rebar.config
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {lib_dirs,
  ["..",

--- a/src/lib/cloudi_service_oauth1/src/cloudi_service_oauth1.erl
+++ b/src/lib/cloudi_service_oauth1/src/cloudi_service_oauth1.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_service_oauth1/src/cloudi_service_oauth1_data.erl
+++ b/src/lib/cloudi_service_oauth1/src/cloudi_service_oauth1_data.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_service_oauth1/src/cloudi_service_oauth1_db.erl
+++ b/src/lib/cloudi_service_oauth1/src/cloudi_service_oauth1_db.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_service_oauth1/src/cloudi_service_oauth1_db_pgsql.erl
+++ b/src/lib/cloudi_service_oauth1/src/cloudi_service_oauth1_db_pgsql.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_service_oauth1/src/cloudi_service_oauth1_db_riak.erl
+++ b/src/lib/cloudi_service_oauth1/src/cloudi_service_oauth1_db_riak.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_service_oauth1/src/cloudi_service_oauth1_parse.erl
+++ b/src/lib/cloudi_service_oauth1/src/cloudi_service_oauth1_parse.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_service_oauth1/test_ct/cloudi_service_oauth1_SUITE.erl
+++ b/src/lib/cloudi_service_oauth1/test_ct/cloudi_service_oauth1_SUITE.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 -module(cloudi_service_oauth1_SUITE).
 -behaviour(cloudi_service).
 

--- a/src/lib/cloudi_service_queue/rebar.config
+++ b/src/lib/cloudi_service_queue/rebar.config
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {lib_dirs,
  ["..",

--- a/src/lib/cloudi_service_queue/src/cloudi_service_queue.app.src.in
+++ b/src/lib/cloudi_service_queue/src/cloudi_service_queue.app.src.in
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {application, cloudi_service_queue, 
   [{description, "CloudI Persistent Queue Service"},

--- a/src/lib/cloudi_service_queue/src/cloudi_service_queue.erl
+++ b/src/lib/cloudi_service_queue/src/cloudi_service_queue.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_service_queue/src/cloudi_write_ahead_logging.erl
+++ b/src/lib/cloudi_service_queue/src/cloudi_write_ahead_logging.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_service_queue/test_ct/cloudi_service_queue_SUITE.erl
+++ b/src/lib/cloudi_service_queue/test_ct/cloudi_service_queue_SUITE.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 -module(cloudi_service_queue_SUITE).
 -behaviour(cloudi_service).
 

--- a/src/lib/cloudi_service_queue/test_ct/cloudi_write_ahead_logging_SUITE.erl
+++ b/src/lib/cloudi_service_queue/test_ct/cloudi_write_ahead_logging_SUITE.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 -module(cloudi_write_ahead_logging_SUITE).
 
 %% CT callbacks

--- a/src/lib/cloudi_service_quorum/rebar.config
+++ b/src/lib/cloudi_service_quorum/rebar.config
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {lib_dirs,
  ["..",

--- a/src/lib/cloudi_service_quorum/src/cloudi_service_quorum.app.src.in
+++ b/src/lib/cloudi_service_quorum/src/cloudi_service_quorum.app.src.in
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {application, cloudi_service_quorum, 
   [{description, "CloudI Quorum Service"},

--- a/src/lib/cloudi_service_quorum/src/cloudi_service_quorum.erl
+++ b/src/lib/cloudi_service_quorum/src/cloudi_service_quorum.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_service_quorum/test_ct/cloudi_service_quorum_SUITE.erl
+++ b/src/lib/cloudi_service_quorum/test_ct/cloudi_service_quorum_SUITE.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 -module(cloudi_service_quorum_SUITE).
 -behaviour(cloudi_service).
 

--- a/src/lib/cloudi_service_router/src/cloudi_service_router.app.src.in
+++ b/src/lib/cloudi_service_router/src/cloudi_service_router.app.src.in
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {application, cloudi_service_router, 
   [{description, "CloudI Router Service"},

--- a/src/lib/cloudi_service_router/src/cloudi_service_router.erl
+++ b/src/lib/cloudi_service_router/src/cloudi_service_router.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_service_tcp/src/cloudi_service_tcp.app.src.in
+++ b/src/lib/cloudi_service_tcp/src/cloudi_service_tcp.app.src.in
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {application, cloudi_service_tcp, 
   [{description, "TCP CloudI Service"},

--- a/src/lib/cloudi_service_tcp/src/cloudi_service_tcp.erl
+++ b/src/lib/cloudi_service_tcp/src/cloudi_service_tcp.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_service_timers/src/cloudi_service_timers.app.src.in
+++ b/src/lib/cloudi_service_timers/src/cloudi_service_timers.app.src.in
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {application, cloudi_service_timers, 
   [{description, "Timers CloudI Service"},

--- a/src/lib/cloudi_service_timers/src/cloudi_service_timers.erl
+++ b/src/lib/cloudi_service_timers/src/cloudi_service_timers.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_service_udp/src/cloudi_service_udp.app.src.in
+++ b/src/lib/cloudi_service_udp/src/cloudi_service_udp.app.src.in
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {application, cloudi_service_udp, 
   [{description, "UDP CloudI Service"},

--- a/src/lib/cloudi_service_udp/src/cloudi_service_udp.erl
+++ b/src/lib/cloudi_service_udp/src/cloudi_service_udp.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_service_validate/rebar.config
+++ b/src/lib/cloudi_service_validate/rebar.config
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {lib_dirs,
  ["..",

--- a/src/lib/cloudi_service_validate/src/cloudi_service_validate.app.src.in
+++ b/src/lib/cloudi_service_validate/src/cloudi_service_validate.app.src.in
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {application, cloudi_service_validate, 
   [{description, "CloudI Validate Service"},

--- a/src/lib/cloudi_service_validate/src/cloudi_service_validate.erl
+++ b/src/lib/cloudi_service_validate/src/cloudi_service_validate.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cloudi_service_validate/test_ct/cloudi_service_validate_SUITE.erl
+++ b/src/lib/cloudi_service_validate/test_ct/cloudi_service_validate_SUITE.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%------------------------------------------------------------------------
 %%% @doc
 %%% ==CloudI Service Validate Tests==

--- a/src/lib/cloudi_service_zeromq/src/cloudi_service_zeromq.app.src.in
+++ b/src/lib/cloudi_service_zeromq/src/cloudi_service_zeromq.app.src.in
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {application, cloudi_service_zeromq, 
   [{description, "ZeroMQ CloudI Service"},

--- a/src/lib/cloudi_service_zeromq/src/cloudi_service_zeromq.erl
+++ b/src/lib/cloudi_service_zeromq/src/cloudi_service_zeromq.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cpg/include/cpg_data.hrl
+++ b/src/lib/cpg/include/cpg_data.hrl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 -record(cpg_data,
     {

--- a/src/lib/cpg/src/cpg.app.src
+++ b/src/lib/cpg/src/cpg.app.src
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {application, cpg, 
   [{description, "CloudI Process Groups"},

--- a/src/lib/cpg/src/cpg.erl
+++ b/src/lib/cpg/src/cpg.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cpg/src/cpg_app.erl
+++ b/src/lib/cpg/src/cpg_app.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cpg/src/cpg_callbacks.erl
+++ b/src/lib/cpg/src/cpg_callbacks.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cpg/src/cpg_constants.hrl
+++ b/src/lib/cpg/src/cpg_constants.hrl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 % CPG constants for changing process group functionality
 

--- a/src/lib/cpg/src/cpg_data.erl
+++ b/src/lib/cpg/src/cpg_data.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cpg/src/cpg_logging.hrl
+++ b/src/lib/cpg/src/cpg_logging.hrl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 % include the proper logging macros
 

--- a/src/lib/cpg/src/cpg_logging_default.hrl
+++ b/src/lib/cpg/src/cpg_logging_default.hrl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 -define(LOG_FATAL(Format, Args),
     error_logger:error_msg(Format, Args)).

--- a/src/lib/cpg/src/cpg_sup.erl
+++ b/src/lib/cpg/src/cpg_sup.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cpg/src/supervisor_cpg.erl
+++ b/src/lib/cpg/src/supervisor_cpg.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cpg/src/supervisor_cpg_spawn.erl
+++ b/src/lib/cpg/src/supervisor_cpg_spawn.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cpg/src/supervisor_cpg_sup.erl
+++ b/src/lib/cpg/src/supervisor_cpg_sup.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cpg/test/cpg_test.erl
+++ b/src/lib/cpg/test/cpg_test.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/cpg/test/cpg_test_server.erl
+++ b/src/lib/cpg/test/cpg_test_server.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/erlang_term/src/erlang_term.app.src
+++ b/src/lib/erlang_term/src/erlang_term.app.src
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {application, erlang_term,
  [{description, "Erlang Term Info"},

--- a/src/lib/erlang_term/src/erlang_term.erl
+++ b/src/lib/erlang_term/src/erlang_term.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/key2value/src/key2value.erl
+++ b/src/lib/key2value/src/key2value.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/keys1value/src/keys1value.erl
+++ b/src/lib/keys1value/src/keys1value.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/pqueue/src/pqueue.erl
+++ b/src/lib/pqueue/src/pqueue.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/pqueue/src/pqueue2.erl
+++ b/src/lib/pqueue/src/pqueue2.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/pqueue/src/pqueue3.erl
+++ b/src/lib/pqueue/src/pqueue3.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/pqueue/src/pqueue4.erl
+++ b/src/lib/pqueue/src/pqueue4.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/quickrand/src/quickrand.erl
+++ b/src/lib/quickrand/src/quickrand.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/reltool_util/release
+++ b/src/lib/reltool_util/release
@@ -1,7 +1,7 @@
 #!/usr/bin/env escript
 %%!
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% BSD LICENSE

--- a/src/lib/reltool_util/scope
+++ b/src/lib/reltool_util/scope
@@ -1,7 +1,7 @@
 #!/usr/bin/env escript
 %%!
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% BSD LICENSE

--- a/src/lib/reltool_util/src/reltool_util.erl
+++ b/src/lib/reltool_util/src/reltool_util.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/service/include/service.hrl
+++ b/src/lib/service/include/service.hrl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%%

--- a/src/lib/service/include/service_req.hrl
+++ b/src/lib/service/include/service_req.hrl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%%

--- a/src/lib/service/src/service.app.src.in
+++ b/src/lib/service/src/service.app.src.in
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {application, service, 
   [{description, "CloudI Service Behavior"},

--- a/src/lib/service/src/service.erl
+++ b/src/lib/service/src/service.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/trie/src/btrie.erl
+++ b/src/lib/trie/src/btrie.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/trie/src/proper_srv.erl
+++ b/src/lib/trie/src/proper_srv.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/trie/src/trie.erl
+++ b/src/lib/trie/src/trie.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/lib/trie/src/trie.hrl
+++ b/src/lib/trie/src/trie.hrl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%%

--- a/src/lib/trie/src/trie_proper.erl
+++ b/src/lib/trie/src/trie_proper.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 -module(trie_proper).
 -ifdef(TEST).

--- a/src/lib/uuid/src/uuid.erl
+++ b/src/lib/uuid/src/uuid.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/m4/ax_backtrace.m4
+++ b/src/m4/ax_backtrace.m4
@@ -1,5 +1,5 @@
 #-*-Mode:m4;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=m4 fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=m4 fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # SYNOPSIS
 #

--- a/src/m4/ax_boost_check_header.m4
+++ b/src/m4/ax_boost_check_header.m4
@@ -1,5 +1,5 @@
 #-*-Mode:m4;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=m4 fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=m4 fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # SYNOPSIS
 #

--- a/src/m4/ax_check_header_macro.m4
+++ b/src/m4/ax_check_header_macro.m4
@@ -1,5 +1,5 @@
 #-*-Mode:m4;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=m4 fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=m4 fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # SYNOPSIS
 #

--- a/src/m4/ax_check_private_header.m4
+++ b/src/m4/ax_check_private_header.m4
@@ -1,5 +1,5 @@
 #-*-Mode:m4;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=m4 fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=m4 fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # SYNOPSIS
 #

--- a/src/m4/ax_check_private_lib.m4
+++ b/src/m4/ax_check_private_lib.m4
@@ -1,5 +1,5 @@
 #-*-Mode:m4;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=m4 fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=m4 fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # SYNOPSIS
 #

--- a/src/m4/ax_clock_gettime.m4
+++ b/src/m4/ax_clock_gettime.m4
@@ -1,5 +1,5 @@
 #-*-Mode:m4;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=m4 fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=m4 fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # SYNOPSIS
 #

--- a/src/m4/ax_cxx_check_header.m4
+++ b/src/m4/ax_cxx_check_header.m4
@@ -1,5 +1,5 @@
 #-*-Mode:m4;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=m4 fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=m4 fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # SYNOPSIS
 #

--- a/src/m4/ax_erlang_otp_version.m4
+++ b/src/m4/ax_erlang_otp_version.m4
@@ -1,5 +1,5 @@
 #-*-Mode:m4;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=m4 fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=m4 fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # SYNOPSIS
 #

--- a/src/m4/ax_gmp.m4
+++ b/src/m4/ax_gmp.m4
@@ -1,5 +1,5 @@
 #-*-Mode:m4;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=m4 fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=m4 fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # SYNOPSIS
 #

--- a/src/m4/ax_python_c.m4
+++ b/src/m4/ax_python_c.m4
@@ -1,5 +1,5 @@
 #-*-Mode:m4;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=m4 fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=m4 fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # SYNOPSIS
 #

--- a/src/m4/ax_search_private_libs.m4
+++ b/src/m4/ax_search_private_libs.m4
@@ -1,5 +1,5 @@
 #-*-Mode:m4;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=m4 fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=m4 fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # SYNOPSIS
 #

--- a/src/m4/ax_uuid.m4
+++ b/src/m4/ax_uuid.m4
@@ -1,5 +1,5 @@
 #-*-Mode:m4;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=m4 fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=m4 fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # SYNOPSIS
 #

--- a/src/m4/ax_zeromq.m4
+++ b/src/m4/ax_zeromq.m4
@@ -1,5 +1,5 @@
 #-*-Mode:m4;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=m4 fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=m4 fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # SYNOPSIS
 #

--- a/src/m4/ax_zeromq_erlzmq.m4
+++ b/src/m4/ax_zeromq_erlzmq.m4
@@ -1,5 +1,5 @@
 #-*-Mode:m4;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=m4 fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=m4 fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # SYNOPSIS
 #

--- a/src/rebar_src.config.in
+++ b/src/rebar_src.config.in
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {lib_dirs,
  ["lib",

--- a/src/rebar_src_test.config.in
+++ b/src/rebar_src_test.config.in
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {lib_dirs,
  ["lib",

--- a/src/service_api/Makefile.am
+++ b/src/service_api/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 if PYTHON_SUPPORT
     PYTHON_SUBDIR = python

--- a/src/service_api/python/Makefile.am
+++ b/src/service_api/python/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 SUBDIRS = jsonrpclib
 

--- a/src/service_api/python/cloudi_service_api.py
+++ b/src/service_api/python/cloudi_service_api.py
@@ -1,5 +1,5 @@
 #-*-Mode:python;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=python fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=python fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 import sys, os
 _absolute_path = os.path.dirname(os.path.abspath(__file__)).split(os.path.sep)

--- a/src/service_api/python/jsonrpclib/Makefile.am
+++ b/src/service_api/python/jsonrpclib/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 instdir = "$(DESTDIR)$(cloudi_prefix)/service_api/python/jsonrpclib"
 

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 if CXX_SUPPORT
     CXX_SUBDIR = hexpi

--- a/src/tests/echo/Makefile.am
+++ b/src/tests/echo/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 instdir = "$(DESTDIR)$(cloudi_prefix)/tests/echo"
 

--- a/src/tests/echo/echo.py
+++ b/src/tests/echo/echo.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #-*-Mode:python;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=python fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=python fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/tests/environment/Makefile.am
+++ b/src/tests/environment/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 instdir = "$(DESTDIR)$(cloudi_prefix)/tests/environment"
 

--- a/src/tests/environment/environment.py
+++ b/src/tests/environment/environment.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #-*-Mode:python;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=python fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=python fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/tests/hexpi/Makefile.am
+++ b/src/tests/hexpi/Makefile.am
@@ -1,4 +1,4 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 SUBDIRS = cxx_src src

--- a/src/tests/hexpi/cxx_src/Makefile.am
+++ b/src/tests/hexpi/cxx_src/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 instdir = "$(cloudi_prefix)/tests/hexpi/priv"
 inst_PROGRAMS = hexpi

--- a/src/tests/hexpi/cxx_src/assert.cpp
+++ b/src/tests/hexpi/cxx_src/assert.cpp
@@ -1,5 +1,5 @@
 //-*-Mode:C++;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/tests/hexpi/cxx_src/assert.hpp
+++ b/src/tests/hexpi/cxx_src/assert.hpp
@@ -1,5 +1,5 @@
 //-*-Mode:C++;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/tests/hexpi/cxx_src/copy_ptr.hpp
+++ b/src/tests/hexpi/cxx_src/copy_ptr.hpp
@@ -1,5 +1,5 @@
 //-*-Mode:C++;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/tests/hexpi/cxx_src/main.cpp
+++ b/src/tests/hexpi/cxx_src/main.cpp
@@ -1,5 +1,5 @@
 //-*-Mode:C++;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/tests/hexpi/cxx_src/piqpr8_gmp.cpp
+++ b/src/tests/hexpi/cxx_src/piqpr8_gmp.cpp
@@ -1,5 +1,5 @@
 //-*-Mode:C++;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/tests/hexpi/cxx_src/piqpr8_gmp.hpp
+++ b/src/tests/hexpi/cxx_src/piqpr8_gmp.hpp
@@ -1,5 +1,5 @@
 //-*-Mode:C++;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/tests/hexpi/cxx_src/piqpr8_gmp_verify.cpp
+++ b/src/tests/hexpi/cxx_src/piqpr8_gmp_verify.cpp
@@ -1,5 +1,5 @@
 //-*-Mode:C++;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/tests/hexpi/cxx_src/piqpr8_gmp_verify.hpp
+++ b/src/tests/hexpi/cxx_src/piqpr8_gmp_verify.hpp
@@ -1,5 +1,5 @@
 //-*-Mode:C++;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/tests/hexpi/cxx_src/thread_pool.hpp
+++ b/src/tests/hexpi/cxx_src/thread_pool.hpp
@@ -1,5 +1,5 @@
 //-*-Mode:C++;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/tests/hexpi/cxx_src/timer.cpp
+++ b/src/tests/hexpi/cxx_src/timer.cpp
@@ -1,5 +1,5 @@
 //-*-Mode:C++;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/tests/hexpi/cxx_src/timer.hpp
+++ b/src/tests/hexpi/cxx_src/timer.hpp
@@ -1,5 +1,5 @@
 //-*-Mode:C++;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/tests/hexpi/src/Makefile.am
+++ b/src/tests/hexpi/src/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 instdir = "$(cloudi_prefix)/tests/hexpi/ebin"
 directinstdir = "$(DESTDIR)$(instdir)"

--- a/src/tests/hexpi/src/cloudi_service_hexpi.erl
+++ b/src/tests/hexpi/src/cloudi_service_hexpi.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/tests/http/Makefile.am
+++ b/src/tests/http/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 if JAVA_SUPPORT
     SCRIPTS_INSTALL_HOOK = scripts-install

--- a/src/tests/http/service/Makefile.am
+++ b/src/tests/http/service/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 if JAVA_SUPPORT
     SUBDIRS = org jar

--- a/src/tests/http/service/jar/Makefile.am
+++ b/src/tests/http/service/jar/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 instdir = "$(DESTDIR)$(cloudi_prefix)/tests/http/service/jar"
 nodist_noinst_SCRIPTS = service.jar

--- a/src/tests/http/service/org/Makefile.am
+++ b/src/tests/http/service/org/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 SUBDIRS = cloudi
 

--- a/src/tests/http/service/org/cloudi/Makefile.am
+++ b/src/tests/http/service/org/cloudi/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 SUBDIRS = tests
 

--- a/src/tests/http/service/org/cloudi/tests/Makefile.am
+++ b/src/tests/http/service/org/cloudi/tests/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 SUBDIRS = http
 

--- a/src/tests/http/service/org/cloudi/tests/http/Main.java
+++ b/src/tests/http/service/org/cloudi/tests/http/Main.java
@@ -1,5 +1,5 @@
 //-*-Mode:java;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=java fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=java fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/tests/http/service/org/cloudi/tests/http/Makefile.am
+++ b/src/tests/http/service/org/cloudi/tests/http/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 JAVACFLAGS = -Xlint -Werror
 JAVAROOT = $(top_builddir)/tests/http/service/jar/

--- a/src/tests/http/service/org/cloudi/tests/http/Task.java
+++ b/src/tests/http/service/org/cloudi/tests/http/Task.java
@@ -1,5 +1,5 @@
 //-*-Mode:java;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=java fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=java fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/tests/http/service/service.py
+++ b/src/tests/http/service/service.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #-*-Mode:python;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=python fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=python fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/tests/http/service/service.rb
+++ b/src/tests/http/service/service.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 #-*-Mode:ruby;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=ruby fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=ruby fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/tests/http_req/Makefile.am
+++ b/src/tests/http_req/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 if C_SUPPORT
     C_SUBDIR = c_src

--- a/src/tests/http_req/c_src/Makefile.am
+++ b/src/tests/http_req/c_src/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 instdir = "$(cloudi_prefix)/tests/http_req/priv"
 inst_PROGRAMS = http_req

--- a/src/tests/http_req/c_src/main.c
+++ b/src/tests/http_req/c_src/main.c
@@ -1,5 +1,5 @@
 /* -*- coding: utf-8; Mode: C; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*-
- * ex: set softtabstop=4 tabstop=4 shiftwidth=4 expandtab fileencoding=utf-8:
+ * ex: set softtabstop=4 tabstop=4 shiftwidth=4 expandtab fileencoding=utf-8 nomodified:
  *
  * BSD LICENSE
  * 

--- a/src/tests/http_req/http_req.js
+++ b/src/tests/http_req/http_req.js
@@ -1,5 +1,5 @@
 //-*-Mode:javascript;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=javascript fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=javascript fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/tests/http_req/http_req.php
+++ b/src/tests/http_req/http_req.php
@@ -1,6 +1,6 @@
 #!/usr/bin/env php
 <?php //-*-coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=php fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=php fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/tests/http_req/http_req.pl
+++ b/src/tests/http_req/http_req.pl
@@ -1,5 +1,5 @@
 #-*-Mode:perl;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/tests/http_req/http_req.py
+++ b/src/tests/http_req/http_req.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #-*-Mode:python;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=python fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=python fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/tests/http_req/http_req.rb
+++ b/src/tests/http_req/http_req.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 #-*-Mode:ruby;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=ruby fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=ruby fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/tests/http_req/http_req_c.py
+++ b/src/tests/http_req/http_req_c.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #-*-Mode:python;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=python fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=python fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/tests/http_req/jar/Makefile.am
+++ b/src/tests/http_req/jar/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 instdir = "$(DESTDIR)$(cloudi_prefix)/tests/http_req/jar"
 nodist_noinst_SCRIPTS = http_req.jar

--- a/src/tests/http_req/org/Makefile.am
+++ b/src/tests/http_req/org/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 SUBDIRS = cloudi
 

--- a/src/tests/http_req/org/cloudi/Makefile.am
+++ b/src/tests/http_req/org/cloudi/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 SUBDIRS = tests
 

--- a/src/tests/http_req/org/cloudi/tests/Makefile.am
+++ b/src/tests/http_req/org/cloudi/tests/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 SUBDIRS = http_req
 

--- a/src/tests/http_req/org/cloudi/tests/http_req/Main.java
+++ b/src/tests/http_req/org/cloudi/tests/http_req/Main.java
@@ -1,5 +1,5 @@
 //-*-Mode:java;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=java fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=java fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/tests/http_req/org/cloudi/tests/http_req/Makefile.am
+++ b/src/tests/http_req/org/cloudi/tests/http_req/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 JAVACFLAGS = -Xlint -Werror
 JAVAROOT = $(top_builddir)/tests/http_req/jar/

--- a/src/tests/http_req/org/cloudi/tests/http_req/Task.java
+++ b/src/tests/http_req/org/cloudi/tests/http_req/Task.java
@@ -1,5 +1,5 @@
 //-*-Mode:java;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=java fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=java fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/tests/http_req/src/Makefile.am
+++ b/src/tests/http_req/src/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 instdir = "$(cloudi_prefix)/tests/http_req/ebin"
 directinstdir = "$(DESTDIR)$(instdir)"

--- a/src/tests/http_req/src/cloudi_service_http_req.erl
+++ b/src/tests/http_req/src/cloudi_service_http_req.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/tests/messaging/Makefile.am
+++ b/src/tests/messaging/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 if CXX_SUPPORT
     CXX_SUBDIR = cxx_src

--- a/src/tests/messaging/MessagingTask.pm
+++ b/src/tests/messaging/MessagingTask.pm
@@ -1,5 +1,5 @@
 #-*-Mode:perl;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/tests/messaging/cxx_src/Makefile.am
+++ b/src/tests/messaging/cxx_src/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 instdir = "$(cloudi_prefix)/tests/messaging/priv"
 inst_PROGRAMS = messaging

--- a/src/tests/messaging/cxx_src/assert.cpp
+++ b/src/tests/messaging/cxx_src/assert.cpp
@@ -1,5 +1,5 @@
 //-*-Mode:C++;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/tests/messaging/cxx_src/assert.hpp
+++ b/src/tests/messaging/cxx_src/assert.hpp
@@ -1,5 +1,5 @@
 //-*-Mode:C++;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/tests/messaging/cxx_src/main.cpp
+++ b/src/tests/messaging/cxx_src/main.cpp
@@ -1,5 +1,5 @@
 /* -*- coding: utf-8; Mode: C; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*-
- * ex: set softtabstop=4 tabstop=4 shiftwidth=4 expandtab fileencoding=utf-8:
+ * ex: set softtabstop=4 tabstop=4 shiftwidth=4 expandtab fileencoding=utf-8 nomodified:
  *
  * BSD LICENSE
  * 

--- a/src/tests/messaging/cxx_src/thread_pool.hpp
+++ b/src/tests/messaging/cxx_src/thread_pool.hpp
@@ -1,5 +1,5 @@
 //-*-Mode:C++;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/tests/messaging/cxx_src/timer.cpp
+++ b/src/tests/messaging/cxx_src/timer.cpp
@@ -1,5 +1,5 @@
 //-*-Mode:C++;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/tests/messaging/cxx_src/timer.hpp
+++ b/src/tests/messaging/cxx_src/timer.hpp
@@ -1,5 +1,5 @@
 //-*-Mode:C++;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=cpp fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/tests/messaging/jar/Makefile.am
+++ b/src/tests/messaging/jar/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 instdir = "$(DESTDIR)$(cloudi_prefix)/tests/messaging/jar"
 nodist_noinst_SCRIPTS = messaging.jar

--- a/src/tests/messaging/messaging.js
+++ b/src/tests/messaging/messaging.js
@@ -1,5 +1,5 @@
 //-*-Mode:javascript;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=javascript fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=javascript fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/tests/messaging/messaging.php
+++ b/src/tests/messaging/messaging.php
@@ -1,6 +1,6 @@
 #!/usr/bin/env php
 <?php //-*-coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=php fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=php fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/tests/messaging/messaging.py
+++ b/src/tests/messaging/messaging.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #-*-Mode:python;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=python fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=python fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/tests/messaging/messaging.rb
+++ b/src/tests/messaging/messaging.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 #-*-Mode:ruby;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=ruby fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=ruby fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/tests/messaging/messaging_c.py
+++ b/src/tests/messaging/messaging_c.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #-*-Mode:python;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=python fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=python fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/tests/messaging/org/Makefile.am
+++ b/src/tests/messaging/org/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 SUBDIRS = cloudi
 

--- a/src/tests/messaging/org/cloudi/Makefile.am
+++ b/src/tests/messaging/org/cloudi/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 SUBDIRS = tests
 

--- a/src/tests/messaging/org/cloudi/tests/Makefile.am
+++ b/src/tests/messaging/org/cloudi/tests/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 SUBDIRS = messaging
 

--- a/src/tests/messaging/org/cloudi/tests/messaging/Main.java
+++ b/src/tests/messaging/org/cloudi/tests/messaging/Main.java
@@ -1,5 +1,5 @@
 //-*-Mode:java;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=java fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=java fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/tests/messaging/org/cloudi/tests/messaging/Makefile.am
+++ b/src/tests/messaging/org/cloudi/tests/messaging/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 JAVACFLAGS = -Xlint -Werror
 JAVAROOT = $(top_builddir)/tests/messaging/jar/

--- a/src/tests/messaging/org/cloudi/tests/messaging/Task.java
+++ b/src/tests/messaging/org/cloudi/tests/messaging/Task.java
@@ -1,5 +1,5 @@
 //-*-Mode:java;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=java fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=java fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/tests/messaging/src/Makefile.am
+++ b/src/tests/messaging/src/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 instdir = "$(cloudi_prefix)/tests/messaging/ebin"
 directinstdir = "$(DESTDIR)$(instdir)"

--- a/src/tests/messaging/src/cloudi_service_messaging_sequence1.erl
+++ b/src/tests/messaging/src/cloudi_service_messaging_sequence1.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/tests/messaging/src/cloudi_service_messaging_sequence2.erl
+++ b/src/tests/messaging/src/cloudi_service_messaging_sequence2.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/tests/messaging/src/cloudi_service_messaging_sequence3.erl
+++ b/src/tests/messaging/src/cloudi_service_messaging_sequence3.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/tests/messaging/src/cloudi_service_messaging_sequence4.erl
+++ b/src/tests/messaging/src/cloudi_service_messaging_sequence4.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/tests/msg_size/Makefile.am
+++ b/src/tests/msg_size/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 if CXX_SUPPORT
     CXX_SUBDIR = cxx_src

--- a/src/tests/msg_size/cxx_src/Makefile.am
+++ b/src/tests/msg_size/cxx_src/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 instdir = "$(cloudi_prefix)/tests/msg_size/priv"
 inst_PROGRAMS = msg_size

--- a/src/tests/msg_size/cxx_src/main.cpp
+++ b/src/tests/msg_size/cxx_src/main.cpp
@@ -1,5 +1,5 @@
 /* -*- coding: utf-8; Mode: C; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*-
- * ex: set softtabstop=4 tabstop=4 shiftwidth=4 expandtab fileencoding=utf-8:
+ * ex: set softtabstop=4 tabstop=4 shiftwidth=4 expandtab fileencoding=utf-8 nomodified:
  *
  * BSD LICENSE
  * 

--- a/src/tests/msg_size/jar/Makefile.am
+++ b/src/tests/msg_size/jar/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 instdir = "$(DESTDIR)$(cloudi_prefix)/tests/msg_size/jar"
 nodist_noinst_SCRIPTS = msg_size.jar

--- a/src/tests/msg_size/msg_size.js
+++ b/src/tests/msg_size/msg_size.js
@@ -1,5 +1,5 @@
 //-*-Mode:javascript;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=javascript fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=javascript fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/tests/msg_size/msg_size.php
+++ b/src/tests/msg_size/msg_size.php
@@ -1,6 +1,6 @@
 #!/usr/bin/env php
 <?php //-*-coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=php fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=php fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/tests/msg_size/msg_size.pl
+++ b/src/tests/msg_size/msg_size.pl
@@ -1,5 +1,5 @@
 #-*-Mode:perl;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=perl fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/tests/msg_size/msg_size.py
+++ b/src/tests/msg_size/msg_size.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #-*-Mode:python;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=python fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=python fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/tests/msg_size/msg_size.rb
+++ b/src/tests/msg_size/msg_size.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 #-*-Mode:ruby;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=ruby fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=ruby fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/tests/msg_size/msg_size_c.py
+++ b/src/tests/msg_size/msg_size_c.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #-*-Mode:python;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=python fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=python fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/tests/msg_size/org/Makefile.am
+++ b/src/tests/msg_size/org/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 SUBDIRS = cloudi
 

--- a/src/tests/msg_size/org/cloudi/Makefile.am
+++ b/src/tests/msg_size/org/cloudi/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 SUBDIRS = tests
 

--- a/src/tests/msg_size/org/cloudi/tests/Makefile.am
+++ b/src/tests/msg_size/org/cloudi/tests/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 SUBDIRS = msg_size
 

--- a/src/tests/msg_size/org/cloudi/tests/msg_size/Main.java
+++ b/src/tests/msg_size/org/cloudi/tests/msg_size/Main.java
@@ -1,5 +1,5 @@
 //-*-Mode:java;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=java fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=java fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/tests/msg_size/org/cloudi/tests/msg_size/Makefile.am
+++ b/src/tests/msg_size/org/cloudi/tests/msg_size/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 JAVACFLAGS = -Xlint -Werror
 JAVAROOT = $(top_builddir)/tests/msg_size/jar/

--- a/src/tests/msg_size/org/cloudi/tests/msg_size/Task.java
+++ b/src/tests/msg_size/org/cloudi/tests/msg_size/Task.java
@@ -1,5 +1,5 @@
 //-*-Mode:java;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-// ex: set ft=java fenc=utf-8 sts=4 ts=4 sw=4 et:
+// ex: set ft=java fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 //
 // BSD LICENSE
 // 

--- a/src/tests/msg_size/src/Makefile.am
+++ b/src/tests/msg_size/src/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 instdir = "$(cloudi_prefix)/tests/msg_size/ebin"
 directinstdir = "$(DESTDIR)$(instdir)"

--- a/src/tests/msg_size/src/cloudi_service_msg_size.erl
+++ b/src/tests/msg_size/src/cloudi_service_msg_size.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/tests/rebar.config
+++ b/src/tests/rebar.config
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 
 {ct_dir, "ct"}.
 {ct_log_dir, "ct/logs"}.

--- a/src/tests/request_rate/Makefile.am
+++ b/src/tests/request_rate/Makefile.am
@@ -1,4 +1,4 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 SUBDIRS = src

--- a/src/tests/request_rate/src/Makefile.am
+++ b/src/tests/request_rate/src/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 instdir = "$(cloudi_prefix)/tests/request_rate/ebin"
 directinstdir = "$(DESTDIR)$(instdir)"

--- a/src/tests/request_rate/src/cloudi_service_request_rate.erl
+++ b/src/tests/request_rate/src/cloudi_service_request_rate.erl
@@ -1,5 +1,5 @@
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 %%%
 %%%------------------------------------------------------------------------
 %%% @doc

--- a/src/tests/service_api/Makefile.am
+++ b/src/tests/service_api/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 instdir = "$(DESTDIR)$(cloudi_prefix)/tests/service_api"
 

--- a/src/tests/service_api/logging_off.py
+++ b/src/tests/service_api/logging_off.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #-*-Mode:python;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=python fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=python fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/tests/service_api/logging_on.py
+++ b/src/tests/service_api/logging_on.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #-*-Mode:python;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=python fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=python fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/tests/service_api/path.py
+++ b/src/tests/service_api/path.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #-*-Mode:python;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=python fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=python fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/tests/service_api/run.py
+++ b/src/tests/service_api/run.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #-*-Mode:python;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=python fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=python fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/tests/websockets/Makefile.am
+++ b/src/tests/websockets/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 instdir = "$(DESTDIR)$(cloudi_prefix)/tests/websockets"
 

--- a/src/tests/websockets/websockets.py
+++ b/src/tests/websockets/websockets.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #-*-Mode:python;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=python fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=python fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 

--- a/src/tests/zeromq/Makefile.am
+++ b/src/tests/zeromq/Makefile.am
@@ -1,5 +1,5 @@
 #-*-Mode:make;coding:utf-8;tab-width:4;c-basic-offset:4-*-
-# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet:
+# ex: set ft=make fenc=utf-8 sts=4 ts=4 sw=4 noet nomod:
 
 instdir = "$(DESTDIR)$(cloudi_prefix)/tests/zeromq"
 

--- a/src/tests/zeromq/run.py
+++ b/src/tests/zeromq/run.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #-*-Mode:python;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
-# ex: set ft=python fenc=utf-8 sts=4 ts=4 sw=4 et:
+# ex: set ft=python fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
 #
 # BSD LICENSE
 # 


### PR DESCRIPTION
Hello. I've changed no code, only `ex:` header settings.

Problem and bug:
When opening any file with `fenc=utf-8` within `ex:` header, vim marks the file as modified because of the transition from no fileencoding value to `utf-8`. It is very annoying to discard non-real changes every time the buffer is closed.

Solution from Linux:
```sh
find ~/git/CloudI/ -type f -exec sed -i 's|\(^.\+ ex:.* fenc=[^:]*\)\(:\?\)|\1 nomod\2|' '{}' \;
find ~/git/CloudI/ -type f -exec sed -i 's|\(^.\+ ex:.* fileencoding=[^:]*\)\(:\?\)|\1 nomodified\2|' '{}' \;
```
Result:
Now files with `fileencoding` or `fenc` set to `utf-8`, have got a `nomodified` or `nomod` flag too, permitting files to be edited from a non-modified state at opening.